### PR TITLE
Improve release.sh to help manage binary growth.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,9 @@ codegen-units = 1
 lto = true
 opt-level = "z"  # Optimize for size.
 panic = "abort"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz"]
+
+[package.metadata.wasm-pack.profile.profiling]
+wasm-opt = ["-Oz", "-g"]

--- a/tool/release.sh
+++ b/tool/release.sh
@@ -18,8 +18,12 @@ ROOT=$DIR/../
     sed -i .bak 's/crate-type = \["cdylib", "rlib"\]/crate-type = ["cdylib"]/' Cargo.toml
 
     rm -rf pkg
+    wasm-pack build --profiling -t web -- --no-default-features
+    mv pkg/replicache_client_bg.wasm pkg/replicache_client_bg.wasm.debug
     wasm-pack build --release -t web -- --no-default-features
-    brotli pkg/replicache_client* -f
+    brotli -f pkg/replicache_client.js pkg/replicache_client_bg.wasm
 
     mv Cargo.toml.bak Cargo.toml
+
+    ls -l pkg/replicache_client.js* pkg/replicache_client_bg.was*[mr] | awk '{print $9 ": " $5}'
 )


### PR DESCRIPTION
o New build product pkg/replicache_client_bg.wasm.debug contains
  debug symbol names, enabling https://github.com/rustwasm/twiggy and
  similar tools to examine what's contributing to binary size.
o The above doesn't seem to take more than another second, likely
  because only link-time options differ between --production and
  --profiling builds.
o Restrict brotli compression to just the files that may go to browsers.
o Switch wasm-opt run (part of wasm-pack) from -O to -Oz, shaving a few
  more bytes.
o Run now ends with formatted output of binary sizes (see below).

Example output:
...
[INFO]: ✨   Done in 0.16s
[INFO]: 📦   Your wasm pkg is ready to publish at /Users/nate/roci/repc2/pkg.
pkg/replicache_client.js: 10068
pkg/replicache_client.js.br: 2492
pkg/replicache_client_bg.wasm: 15243
pkg/replicache_client_bg.wasm.br: 7398