### PR TITLE
Use 'log' crate as a logging facade w/ console_log.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
+dependencies = [
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,10 +489,12 @@ dependencies = [
  "async-std",
  "async-trait",
  "console_error_panic_hook",
+ "console_log",
  "data-encoding",
  "futures",
  "js-sys",
  "lazy_static",
+ "log",
  "nanoserde",
  "sha2",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,14 @@ default = ["console_error_panic_hook"]
 [dependencies]
 async-std = { version = "=1.6.0", features = ["unstable"] }
 async-trait = "0.1.36"
+console_log = { version = "0.2" }
 console_error_panic_hook = { version = "0.1.1", optional = true }
 data-encoding = "1.1.1"
 futures = "0.3.5"
 js-sys = "0.3.40"
 lazy_static = "1.4.0"
 nanoserde = "0.1"
+log = "0.4"
 sha2 = "0.8.1"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.13"

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,7 +1,0 @@
-// A macro to provide `println!(..)`-style syntax for `console.log` logging.
-#[allow(unused_macros)]
-macro_rules! log {
-    ( $( $t:tt )* ) => {
-        web_sys::console::log_1(&format!( $( $t )* ).into());
-    }
-}

--- a/src/kv/idbstore.rs
+++ b/src/kv/idbstore.rs
@@ -1,6 +1,7 @@
 use crate::kv::{Store, StoreError};
 use async_trait::async_trait;
 use futures::channel::oneshot;
+use log::warn;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::IdbDatabase;
@@ -40,7 +41,7 @@ impl IdbStore {
         let (sender, receiver) = oneshot::channel::<()>();
         let callback = Closure::once(move || {
             if let Err(_) = sender.send(()) {
-                log!("oneshot send failed");
+                warn!("oneshot send failed");
             }
         });
         let request_copy = request.clone();
@@ -48,14 +49,14 @@ impl IdbStore {
             let result = match request_copy.result() {
                 Ok(r) => r,
                 Err(e) => {
-                    log!("Error before ugradeneeded: {:?}", e);
+                    warn!("Error before ugradeneeded: {:?}", e);
                     return;
                 }
             };
             let db = web_sys::IdbDatabase::unchecked_from_js(result);
 
             if let Err(e) = db.create_object_store(OBJECT_STORE) {
-                log!("Create object store failed: {:?}", e);
+                warn!("Create object store failed: {:?}", e);
             }
         });
         request.set_onsuccess(Some(callback.as_ref().unchecked_ref()));
@@ -78,7 +79,7 @@ impl Store for IdbStore {
         let (sender, txdonereceiver) = oneshot::channel::<()>();
         let callback = Closure::once(move || {
             if let Err(_) = sender.send(()) {
-                log!("oneshot send failed");
+                warn!("oneshot send failed");
             }
         });
         tx.set_oncomplete(Some(callback.as_ref().unchecked_ref()));
@@ -88,7 +89,7 @@ impl Store for IdbStore {
         let (sender, receiver) = oneshot::channel::<()>();
         let putcallback = Closure::once(move || {
             if let Err(_) = sender.send(()) {
-                log!("oneshot send failed");
+                warn!("oneshot send failed");
             }
         });
         request.set_onsuccess(Some(putcallback.as_ref().unchecked_ref()));
@@ -107,7 +108,7 @@ impl Store for IdbStore {
         let (sender, receiver) = oneshot::channel::<()>();
         let callback = Closure::once(move || {
             if let Err(_) = sender.send(()) {
-                log!("oneshot send failed");
+                warn!("oneshot send failed");
             }
         });
         request.set_onsuccess(Some(callback.as_ref().unchecked_ref()));
@@ -126,7 +127,7 @@ impl Store for IdbStore {
         let (sender, receiver) = oneshot::channel::<()>();
         let callback = Closure::once(move || {
             if let Err(_) = sender.send(()) {
-                log!("oneshot send failed");
+                warn!("oneshot send failed");
             }
         });
         request.set_onsuccess(Some(callback.as_ref().unchecked_ref()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,8 @@ pub mod wasm;
 extern crate async_std;
 #[macro_use]
 extern crate lazy_static;
+extern crate log;
 
-#[macro_use]
-mod console;
 mod dag;
 mod dispatch;
 mod hash;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,3 +1,4 @@
+use std::sync::Once;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
 use wee_alloc;
@@ -32,7 +33,14 @@ pub async fn dispatch(db_name: String, rpc: String, args: String) -> Result<Stri
     }
 }
 
+static INIT: Once = Once::new();
+
 fn init_panic_hook() {
     #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
+    INIT.call_once(|| {
+        if let Err(e) = console_log::init_with_level(log::Level::Info) {
+            web_sys::console::error_1(&format!("Error registering console_log: {}", e).into());
+        }
+    });
 }


### PR DESCRIPTION
This removes the WASM-only dependency on web_sys::console from most of
our sources, instead registering the 'console_log' crate as the log
emitter in src/wasm.rs. When we have non-WASM targets, we can register a
different logger for them from the list at
https://docs.rs/log/0.4.8/log/#available-logging-implementations.

replicache_client.js: 16761 (+2.7%)
replicache_client.js.br: 3613 (+2.4%)
replicache_client_bg.wasm: 131254 (+2%)
replicache_client_bg.wasm.br: 57200 (+1.4%)