### PR TITLE
Add MemStore implementation of kv::Store

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -42,22 +42,18 @@ async fn dispatch_loop(rx: Receiver<Request>) {
                     req.response.send(response).await;
                     continue;
                 }
-                let db = {
-                    let d = &mut dispatcher;
-                    let db = match d.connections.get_mut(&req.db_name[..]) {
-                        Some(v) => v,
-                        None => {
-                            let err = Err(format!("\"{}\" not open", req.db_name));
-                            req.response.send(err).await;
-                            continue;
-                        }
-                    };
-                    db
+                let db = match dispatcher.connections.get_mut(&req.db_name[..]) {
+                    Some(v) => v,
+                    None => {
+                        let err = Err(format!("\"{}\" not open", req.db_name));
+                        req.response.send(err).await;
+                        continue;
+                    }
                 };
                 let response = match req.rpc.as_str() {
-                    "has" => dispatcher.has(&**db, &req.data).await,
-                    "get" => dispatcher.get(&**db, &req.data).await,
-                    "put" => dispatcher.put(&mut **db, &req.data).await,
+                    "has" => Dispatcher::has(&**db, &req.data).await,
+                    "get" => Dispatcher::get(&**db, &req.data).await,
+                    "put" => Dispatcher::put(&mut **db, &req.data).await,
                     _ => Err("Unsupported rpc name".to_string()),
                 };
                 req.response.send(response).await;
@@ -118,7 +114,7 @@ impl Dispatcher {
         Ok("".to_string())
     }
 
-    async fn has(&self, db: &dyn Store, data: &String) -> Response {
+    async fn has(db: &dyn Store, data: &String) -> Response {
         let req: GetRequest = match DeJson::deserialize_json(data) {
             Ok(v) => v,
             Err(_) => return Err("Failed to parse request".into()),
@@ -132,7 +128,7 @@ impl Dispatcher {
         }
     }
 
-    async fn get(&self, db: &dyn Store, data: &String) -> Response {
+    async fn get(db: &dyn Store, data: &String) -> Response {
         let req: GetRequest = match DeJson::deserialize_json(data) {
             Ok(v) => v,
             Err(_) => return Err("Failed to parse request".into()),
@@ -153,7 +149,7 @@ impl Dispatcher {
         }
     }
 
-    async fn put(&self, db: &mut dyn Store, data: &String) -> Response {
+    async fn put(db: &mut dyn Store, data: &String) -> Response {
         let req: PutRequest = match DeJson::deserialize_json(data) {
             Ok(v) => v,
             Err(_) => return Err("Failed to parse request".into()),
@@ -164,7 +160,7 @@ impl Dispatcher {
         }
     }
 
-    async fn debug(&mut self, req: &Request) -> Response {
+    async fn debug(&self, req: &Request) -> Response {
         match req.data.as_str() {
             "open_dbs" => Ok(format!("{:?}", self.connections.keys())),
             _ => Err("Debug command not defined".to_string()),

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -43,14 +43,16 @@ async fn dispatch_loop(rx: Receiver<Request>) {
                     continue;
                 }
                 let db = {
-                    match dispatcher.connections.get_mut(&req.db_name[..]) {
+                    let d = &mut dispatcher;
+                    let db = match d.connections.get_mut(&req.db_name[..]) {
                         Some(v) => v,
                         None => {
                             let err = Err(format!("\"{}\" not open", req.db_name));
                             req.response.send(err).await;
                             continue;
                         }
-                    }
+                    };
+                    db
                 };
                 let response = match req.rpc.as_str() {
                     "has" => dispatcher.has(&**db, &req.data).await,

--- a/src/kv/idbstore.rs
+++ b/src/kv/idbstore.rs
@@ -1,7 +1,6 @@
 use crate::kv::{Store, StoreError};
 use async_trait::async_trait;
 use futures::channel::oneshot;
-use std::fmt;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::IdbDatabase;

--- a/src/kv/idbstore.rs
+++ b/src/kv/idbstore.rs
@@ -21,14 +21,6 @@ impl From<futures::channel::oneshot::Canceled> for StoreError {
     }
 }
 
-impl fmt::Display for StoreError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            StoreError::Str(s) => write!(f, "{}", s),
-        }
-    }
-}
-
 pub struct IdbStore {
     idb: IdbDatabase,
 }
@@ -79,7 +71,7 @@ impl IdbStore {
 
 #[async_trait(?Send)]
 impl Store for IdbStore {
-    async fn put(self: &Self, key: &str, value: &[u8]) -> Result<()> {
+    async fn put(&mut self, key: &str, value: &[u8]) -> Result<()> {
         let tx = self
             .idb
             .transaction_with_str_and_mode(OBJECT_STORE, web_sys::IdbTransactionMode::Readwrite)?;
@@ -109,7 +101,7 @@ impl Store for IdbStore {
         Ok(())
     }
 
-    async fn has(self: &Self, key: &str) -> Result<bool> {
+    async fn has(&self, key: &str) -> Result<bool> {
         let tx = self.idb.transaction_with_str(OBJECT_STORE)?;
         let store = tx.object_store(OBJECT_STORE)?;
         let request = store.count_with_key(&key.into())?;
@@ -128,7 +120,7 @@ impl Store for IdbStore {
         })
     }
 
-    async fn get(self: &Self, key: &str) -> Result<Option<Vec<u8>>> {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
         let tx = self.idb.transaction_with_str(OBJECT_STORE)?;
         let store = tx.object_store(OBJECT_STORE)?;
         let request = store.get(&key.into())?;

--- a/src/kv/memstore.rs
+++ b/src/kv/memstore.rs
@@ -1,7 +1,6 @@
-use async_trait::async_trait;
 use crate::kv::{Store, StoreError};
+use async_trait::async_trait;
 use std::collections::HashMap;
-use std::fmt;
 
 type Result<T> = std::result::Result<T, StoreError>;
 
@@ -10,8 +9,11 @@ pub struct MemStore {
 }
 
 impl MemStore {
-    pub async fn new(name: &str) -> Result<Option<MemStore>> {
-        Ok(Some(MemStore{map: HashMap::new()}))
+    #[allow(dead_code)]
+    pub async fn new() -> Result<Option<MemStore>> {
+        Ok(Some(MemStore {
+            map: HashMap::new(),
+        }))
     }
 }
 

--- a/src/kv/memstore.rs
+++ b/src/kv/memstore.rs
@@ -10,10 +10,10 @@ pub struct MemStore {
 
 impl MemStore {
     #[allow(dead_code)]
-    pub async fn new() -> Result<Option<MemStore>> {
-        Ok(Some(MemStore {
+    pub fn new() -> MemStore {
+        MemStore {
             map: HashMap::new(),
-        }))
+        }
     }
 }
 
@@ -33,5 +33,23 @@ impl Store for MemStore {
             None => Ok(None),
             Some(v) => Ok(Some(v.to_vec())),
         }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+
+    #[test]
+    fn basics() {
+        let mut ms = MemStore::new();
+        assert_eq!(false, block_on(ms.has("foo")).unwrap());
+        assert_eq!(None, block_on(ms.get("foo")).unwrap());
+        block_on(ms.put("foo", "bar".as_bytes())).unwrap();
+        assert_eq!(true, block_on(ms.has("foo")).unwrap());
+        assert_eq!(Some("bar".as_bytes().to_vec()),
+            block_on(ms.get("foo")).unwrap());
+        assert_eq!(false, block_on(ms.has("bar")).unwrap());
+        assert_eq!(None, block_on(ms.get("bar")).unwrap());
     }
 }

--- a/src/kv/memstore.rs
+++ b/src/kv/memstore.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+use crate::kv::{Store, StoreError};
+use std::collections::HashMap;
+use std::fmt;
+
+type Result<T> = std::result::Result<T, StoreError>;
+
+pub struct MemStore {
+    map: HashMap<String, Vec<u8>>,
+}
+
+impl MemStore {
+    pub async fn new(name: &str) -> Result<Option<MemStore>> {
+        Ok(Some(MemStore{map: HashMap::new()}))
+    }
+}
+
+#[async_trait(?Send)]
+impl Store for MemStore {
+    async fn put(&mut self, key: &str, value: &[u8]) -> Result<()> {
+        self.map.insert(key.to_string(), value.to_vec());
+        Ok(())
+    }
+
+    async fn has(&self, key: &str) -> Result<bool> {
+        Ok(self.map.contains_key(key))
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        match self.map.get(key) {
+            None => Ok(None),
+            Some(v) => Ok(Some(v.to_vec())),
+        }
+    }
+}

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -1,17 +1,27 @@
 pub mod idbstore;
+pub mod memstore;
 
 use async_trait::async_trait;
+use std::fmt;
 
 #[derive(Debug)]
 pub enum StoreError {
     Str(String),
 }
 
+impl fmt::Display for StoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StoreError::Str(s) => write!(f, "{}", s),
+        }
+    }
+}
+
 type Result<T> = std::result::Result<T, StoreError>;
 
 #[async_trait(?Send)]
 pub trait Store {
-    async fn put(self: &Self, key: &str, value: &[u8]) -> Result<()>;
-    async fn has(self: &Self, key: &str) -> Result<bool>;
-    async fn get(self: &Self, key: &str) -> Result<Option<Vec<u8>>>;
+    async fn put(&mut self, key: &str, value: &[u8]) -> Result<()>;
+    async fn has(&self, key: &str) -> Result<bool>;
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>>;
 }


### PR DESCRIPTION
This required changing Store::put() to borrow self mutably. Followed it up the tree and feel I have it right, but borrow checker disagrees:

```
rror[E0502]: cannot borrow `dispatcher` as immutable because it is also borrowed as mutable
  --> src/dispatch.rs:56:30
   |
46 |                     match dispatcher.connections.get_mut(&req.db_name[..]) {
   |                           ---------------------- mutable borrow occurs here
...
56 |                     "has" => dispatcher.has(&**db, &req.data).await,
   |                              ^^^^^^^^^^     ----- mutable borrow later used here
   |                              |
   |                              immutable borrow occurs here
```

The way I see it, dispatcher is borrowed mutably to call `get_mut` but that reference is immediately dropped when the `let db = {...}` scope exits. For some reason borrow checker sees the mutable ref as living on, same lifetime as the db reference.