### PR TITLE
Implement Store::Read/Write traits for IdbStore.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +515,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +576,7 @@ dependencies = [
  "lazy_static",
  "log",
  "nanoserde",
+ "rand",
  "sha2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -622,6 +682,12 @@ name = "waker-fn"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9571542c2ce85ce642e6b58b3364da2fb53526360dfb7c211add4f5c23105ff7"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ wee_alloc = "0.4.5"
 
 [dev-dependencies]
 async-std = { version = "=1.6.0", features = ["attributes", "unstable"] }
+rand = { version = "0.7.3", features = ["wasm-bindgen"] }
 wasm-bindgen-test = "0.3.0"
 
 [dependencies.web-sys]

--- a/src/kv/idbstore.rs
+++ b/src/kv/idbstore.rs
@@ -1,10 +1,20 @@
 use crate::kv::{Read, Result, Store, StoreError, Write};
+use async_std::sync::{Arc, Condvar, Mutex};
 use async_trait::async_trait;
 use futures::channel::oneshot;
+use futures::future::join_all;
 use log::warn;
+use std::collections::HashMap;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
-use web_sys::IdbDatabase;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::{IdbDatabase, IdbObjectStore, IdbTransaction};
+
+impl From<String> for StoreError {
+    fn from(err: String) -> StoreError {
+        StoreError::Str(err)
+    }
+}
 
 impl From<JsValue> for StoreError {
     fn from(err: JsValue) -> StoreError {
@@ -70,11 +80,11 @@ impl IdbStore {
 #[async_trait(?Send)]
 impl Store for IdbStore {
     async fn read<'a>(&'a self) -> Result<Box<dyn Read + 'a>> {
-        return Err(StoreError::Str("Not supported".to_string()));
+        Ok(Box::new(ReadTransaction::new(self)?))
     }
 
     async fn write<'a>(&'a self) -> Result<Box<dyn Write + 'a>> {
-        return Err(StoreError::Str("Not supported".into()));
+        Ok(Box::new(WriteTransaction::new(self)?))
     }
 
     async fn put(&mut self, key: &str, value: &[u8]) -> Result<()> {
@@ -143,5 +153,216 @@ impl Store for IdbStore {
             v if v.is_undefined() => None,
             v => Some(js_sys::Uint8Array::new(&v).to_vec()),
         })
+    }
+}
+
+struct ReadTransaction {
+    tx: IdbTransaction,
+    store: IdbObjectStore,
+}
+
+impl ReadTransaction {
+    fn new(idb: &IdbStore) -> Result<ReadTransaction> {
+        let tx = idb.idb.transaction_with_str(OBJECT_STORE)?;
+        Ok(ReadTransaction {
+            store: tx.object_store(OBJECT_STORE)?,
+            tx: tx,
+        })
+    }
+}
+
+#[async_trait(?Send)]
+impl Read for ReadTransaction {
+    async fn has(&self, key: &str) -> Result<bool> {
+        let request = self.store.count_with_key(&key.into())?;
+        let (sender, receiver) = oneshot::channel::<()>();
+        let callback = Closure::once(move || {
+            if let Err(_) = sender.send(()) {
+                warn!("oneshot send failed");
+            }
+        });
+        request.set_onsuccess(Some(callback.as_ref().unchecked_ref()));
+        request.set_onerror(Some(callback.as_ref().unchecked_ref()));
+        receiver.await?;
+        Ok(match request.result()?.as_f64() {
+            Some(v) if v >= 1.0 => true,
+            _ => false,
+        })
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        let request = self.store.get(&key.into())?;
+        let (sender, receiver) = oneshot::channel::<()>();
+        let callback = Closure::once(move || {
+            if let Err(_) = sender.send(()) {
+                warn!("oneshot send failed");
+            }
+        });
+        request.set_onsuccess(Some(callback.as_ref().unchecked_ref()));
+        request.set_onerror(Some(callback.as_ref().unchecked_ref()));
+        receiver.await?;
+        Ok(match request.result()? {
+            v if v.is_undefined() => None,
+            v => Some(js_sys::Uint8Array::new(&v).to_vec()),
+        })
+    }
+}
+
+#[derive(PartialEq, Eq, Debug)]
+enum WriteState {
+    Open,
+    Committed,
+    Aborted,
+    Errored,
+}
+
+struct WriteTransaction {
+    rt: ReadTransaction,
+    pending: Mutex<HashMap<String, Vec<u8>>>,
+    pair: Arc<(Mutex<WriteState>, Condvar)>,
+    callbacks: Vec<Closure<dyn FnMut()>>,
+}
+
+impl WriteTransaction {
+    fn new(idb: &IdbStore) -> Result<WriteTransaction> {
+        let tx = idb
+            .idb
+            .transaction_with_str_and_mode(OBJECT_STORE, web_sys::IdbTransactionMode::Readwrite)?;
+        let mut wt = WriteTransaction {
+            rt: ReadTransaction {
+                store: tx.object_store(OBJECT_STORE)?,
+                tx: tx,
+            },
+            pair: Arc::new((Mutex::new(WriteState::Open), Condvar::new())),
+            pending: Mutex::new(HashMap::new()),
+            callbacks: Vec::with_capacity(3),
+        };
+
+        let tx = &wt.rt.tx;
+        let callback = wt.tx_callback(WriteState::Committed);
+        tx.set_oncomplete(Some(callback.as_ref().unchecked_ref()));
+        wt.callbacks.push(callback);
+
+        let callback = wt.tx_callback(WriteState::Aborted);
+        tx.set_onabort(Some(callback.as_ref().unchecked_ref()));
+        wt.callbacks.push(callback);
+
+        let callback = wt.tx_callback(WriteState::Errored);
+        tx.set_onerror(Some(callback.as_ref().unchecked_ref()));
+        wt.callbacks.push(callback);
+
+        Ok(wt)
+    }
+
+    fn tx_callback(&self, new_state: WriteState) -> Closure<dyn FnMut()> {
+        let pair = self.pair.clone();
+        Closure::once(move || {
+            spawn_local(async move {
+                let (lock, cv) = &*pair;
+                let mut state = lock.lock().await;
+                *state = new_state;
+                cv.notify_one();
+            });
+        })
+    }
+}
+
+#[async_trait(?Send)]
+impl Read for WriteTransaction {
+    async fn has(&self, key: &str) -> Result<bool> {
+        match self.pending.lock().await.contains_key(key) {
+            true => Ok(true),
+            false => self.rt.has(key).await,
+        }
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        match self.pending.lock().await.get(key) {
+            Some(v) => Ok(Some(v.to_vec())),
+            None => self.rt.get(key).await,
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl Write for WriteTransaction {
+    fn as_read<'a>(&'a self) -> &'a dyn Read {
+        self
+    }
+
+    async fn put(&self, key: &str, value: &[u8]) -> Result<()> {
+        self.pending
+            .lock()
+            .await
+            .insert(key.to_string(), value.to_vec());
+        Ok(())
+    }
+
+    async fn commit(self: Box<Self>) -> Result<()> {
+        // Define rollback() to succeed if no writes have occurred, even if
+        // the underlying transaction has exited. Users who expose themselves
+        // to this would notice if they performed any reads after exposing
+        // themselves to a situation where the transaction would autocommit.
+        let pending = self.pending.lock().await;
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        let store = self.rt.tx.object_store(OBJECT_STORE)?;
+        let mut callbacks = Vec::with_capacity(pending.len());
+        let mut puts: Vec<oneshot::Receiver<()>> = Vec::with_capacity(pending.len());
+        for (key, value) in pending.iter() {
+            let request = store.put_with_key(&js_sys::Uint8Array::from(&value[..]), &key.into())?;
+            let (sender, receiver) = oneshot::channel::<()>();
+            let callback = Closure::once(move || {
+                if let Err(_) = sender.send(()) {
+                    warn!("oneshot send failed");
+                }
+            });
+            request.set_onsuccess(Some(callback.as_ref().unchecked_ref()));
+            callbacks.push(callback);
+            puts.push(receiver);
+        }
+        join_all(puts).await;
+
+        let (lock, cv) = &*self.pair;
+        let state = cv
+            .wait_until(lock.lock().await, |state| *state != WriteState::Open)
+            .await;
+        match self.rt.tx.error() {
+            Some(e) => return Err(format!("{:?}", e).into()),
+            _ => (),
+        }
+        if *state != WriteState::Committed {
+            return Err(StoreError::Str("Transaction aborted".into()));
+        }
+        Ok(())
+    }
+
+    async fn rollback(self: Box<Self>) -> Result<()> {
+        // Define rollback() to succeed if no writes have occurred, even if
+        // the underlying transaction has exited.
+        if self.pending.lock().await.is_empty() {
+            return Ok(());
+        }
+
+        let (lock, cv) = &*self.pair;
+        match *lock.lock().await {
+            WriteState::Committed | WriteState::Aborted => return Ok(()),
+            _ => (),
+        }
+
+        self.rt.tx.abort()?;
+        let state = cv
+            .wait_until(lock.lock().await, |state| *state != WriteState::Open)
+            .await;
+        match self.rt.tx.error() {
+            Some(e) => return Err(format!("{:?}", e).into()),
+            _ => (),
+        }
+        if *state != WriteState::Aborted {
+            return Err(StoreError::Str("Transaction abort failed".into()));
+        }
+        Ok(())
     }
 }

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -42,6 +42,6 @@ pub trait Write: Read {
     async fn put(&self, key: &str, value: &[u8]) -> Result<()>;
     // TODO(nate): async fn del(&self, key: &str) -> Result<()>;
 
-    async fn commit(&mut self) -> Result<()>;
-    async fn rollback(&mut self) -> Result<()>;
+    async fn commit(self: Box<Self>) -> Result<()>;
+    async fn rollback(self: Box<Self>) -> Result<()>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,11 @@ extern crate log;
 mod dag;
 mod dispatch;
 mod hash;
+
+#[cfg(not(default))]
+pub mod kv;
+
+#[cfg(default)]
 mod kv;
+
 mod prolly;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -6,6 +6,8 @@ use wee_alloc;
 
 use crate::dag::{chunk, key};
 use crate::dispatch;
+use crate::kv::idbstore::IdbStore;
+use crate::kv::Store;
 use crate::prolly::chunker::Chunker;
 
 // Use `wee_alloc` as the global allocator.
@@ -25,6 +27,15 @@ pub async fn exercise_dag() {
         c.meta().map(|b| b.to_vec()),
     );
     warn!("{:?} {:?} {:?} {:?} {:?}", c, c2, k1, k2, k3);
+}
+
+#[cfg(not(default))]
+pub async fn new_idbstore(name: String) -> Option<Box<dyn Store>> {
+    init_panic_hook();
+    match IdbStore::new(&name).await {
+        Ok(Some(v)) => Some(Box::new(v)),
+        _ => None,
+    }
 }
 
 #[wasm_bindgen]

--- a/tests/idbstore.rs
+++ b/tests/idbstore.rs
@@ -1,0 +1,111 @@
+pub mod idbstore {
+
+    use rand::Rng;
+    use replicache_client::kv::Store;
+    use replicache_client::wasm;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    use wasm_bindgen_test::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    async fn new_store() -> Box<dyn Store> {
+        let mut rng = rand::thread_rng();
+        let name = std::iter::repeat(())
+            .map(|()| rng.sample(rand::distributions::Alphanumeric))
+            .take(12)
+            .collect();
+        wasm::new_idbstore(name)
+            .await
+            .expect("IdbStore::new failed")
+    }
+
+    // TODO(nate): Test entering Errored state.
+
+    #[wasm_bindgen_test]
+    async fn simple_commit() {
+        let store = new_store().await;
+
+        // Start a write transaction, and put a value on it.
+        let wt = store.write().await.unwrap();
+        assert_eq!(false, wt.has("bar").await.unwrap());
+        wt.put("bar", b"baz").await.unwrap();
+        assert_eq!(Some(b"baz".to_vec()), wt.get("bar").await.unwrap());
+        wt.commit().await.unwrap();
+
+        // Verify that the write was effective.
+        let rt = store.read().await.unwrap();
+        assert_eq!(true, rt.has("bar").await.unwrap());
+        assert_eq!(Some(b"baz".to_vec()), rt.get("bar").await.unwrap());
+    }
+
+    #[wasm_bindgen_test]
+    async fn read_only_commit() {
+        let store = new_store().await;
+
+        let wt = store.write().await.unwrap();
+        assert_eq!(false, wt.has("bar").await.unwrap());
+        wt.commit().await.unwrap();
+    }
+
+    #[wasm_bindgen_test]
+    async fn read_only_rollback() {
+        let store = new_store().await;
+
+        let wt = store.write().await.unwrap();
+        assert_eq!(false, wt.has("bar").await.unwrap());
+        wt.rollback().await.unwrap();
+    }
+
+    #[wasm_bindgen_test]
+    async fn simple_rollback() {
+        let store = new_store().await;
+
+        // Start a write transaction and put a value, then abort.
+        let wt = store.write().await.unwrap();
+        wt.put("bar", b"baz").await.unwrap();
+        wt.rollback().await.unwrap();
+
+        let rt = store.read().await.unwrap();
+        assert_eq!(None, rt.get("bar").await.unwrap());
+    }
+
+    #[wasm_bindgen_test]
+    async fn autocommit_rolls_back() {
+        let store = new_store().await;
+        let rt = store.read().await.unwrap();
+        assert_eq!(false, rt.has("bar").await.unwrap());
+
+        // Start a write transaction and put a value.
+        let wt = store.write().await.unwrap();
+        wt.put("bar", b"baz").await.unwrap();
+
+        // Start a read transaction and verify isolation.
+        let rt = store.read().await.unwrap();
+        assert_eq!(None, rt.get("bar").await.unwrap());
+
+        // Verify that attempts to commit will now fail, and the put was lost.
+        assert!(wt.commit().await.is_err());
+        let rt = store.read().await.unwrap();
+        assert_eq!(None, rt.get("bar").await.unwrap());
+    }
+
+    #[wasm_bindgen_test]
+    async fn autocommit_rollback_succeeds() {
+        let store = new_store().await;
+        let rt = store.read().await.unwrap();
+        assert_eq!(false, rt.has("bar").await.unwrap());
+
+        // Start a write transaction and put a value.
+        let wt = store.write().await.unwrap();
+        wt.put("bar", b"baz").await.unwrap();
+
+        // Start a read transaction and verify isolation.
+        let rt = store.read().await.unwrap();
+        assert_eq!(None, rt.get("bar").await.unwrap());
+
+        // Verify that an attempted rollback succeeds, and the put was lost.
+        wt.rollback().await.unwrap();
+        let rt = store.read().await.unwrap();
+        assert_eq!(None, rt.get("bar").await.unwrap());
+    }
+}


### PR DESCRIPTION
o This also switches Store::commit()/rollback() to move the Store in,
  letting the compiler prevent any subsequent uses. The same pattern had
  to be applied to dag as well otherwise it looked like a dag::Write
  still held a reference. Removed some tests that are now meaningless
  and the compiler wouldn't let stand anymore.

o Moved a few 'use' statements at the top of sources into their test
  modules to avoid unused-use warnings.

o In IdbStore::Write, management of callbacks and state got weird. What
  I settled on is registering transaction oncommit/onabort/onerror
  callbacks when the transaction is first started, and having these
  manage a state variable on the WriteTransaction. Through a muxex and
  condvar, commit() and rollback() are able to query this state or wait
  for it to make a transition.

o All application of pending changes is held back until commit() to
  (hopefully!) ensure that no changes are applied and then autocommitted
  unless they all would be. In future commits, I need to cause the
  IdbTransaction to transition to the error state to further refine
  handling here.

o The Results I return on commit() and rollback() may need some work,
  for instance if the user called commit(), we get a commited callback,
  but the transaction is in an error state, should we really fail the
  commit() call? I'm not happy here yet.

o To enable the IdbStore integration tests, I tried to export a
  new_idbstore() function from wasm.rs, but only for testing. However,
  trying to limit to cfg(test) doesn't work (doctests?), so for now it's
  using cfg(not(default)). I don't even know what that means, but it
  compiles with no warnings.