### PR TITLE
Initial commit of WebAssembly benchmark framework.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,14 @@ jobs:
     - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
     - run: wasm-pack test --chrome --headless
 
+  wasmbench:
+    name: Wasm Bench
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+    - run: ./tool/benchmark
+
   wasmsize:
     name: Wasm Size
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-    - run: ./tool/benchmark
+    - run: ./tool/benchmark | tee > wasm-bench.txt
+    - uses: actions/upload-artifact@v2
+      with:
+        name: wasm-bench.txt
+        path: wasm-bench.txt
 
   wasmsize:
     name: Wasm Size

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.40"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce10c23ad2ea25ceca0093bd3192229da4c5b3c0f2de499c1ecac0d98d452177"
+checksum = "52732a3d3ad72c58ad2dc70624f9c17b46ecd0943b9a4f1ee37c4c18c5d983e2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -578,6 +578,7 @@ dependencies = [
  "nanoserde",
  "rand",
  "sha2",
+ "wasm-bench",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -690,10 +691,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
+name = "wasm-bench"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "wasm-bench-macro",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bench-macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "wasm-bindgen"
-version = "0.2.63"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
+checksum = "f3edbcc9536ab7eababcc6d2374a0b7bfe13a2b6d562c5e07f370456b1a8f33d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -701,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.63"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded84f06e0ed21499f6184df0e0cb3494727b0c5da89534e0fcc55c51d812101"
+checksum = "89ed2fb8c84bfad20ea66b26a3743f3e7ba8735a69fe7d95118c33ec8fc1244d"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -728,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.63"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838e423688dac18d73e31edce74ddfac468e37b1506ad163ffaf0a46f703ffe3"
+checksum = "eb071268b031a64d92fc6cf691715ca5a40950694d8f683c5bb43db7c730929e"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -738,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.63"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
+checksum = "cf592c807080719d1ff2f245a687cbadb3ed28b2077ed7084b47aba8b691f2c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -751,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.63"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd"
+checksum = "72b6c0220ded549d63860c78c38f3bcc558d1ca3f4efa74942c536ddbbb55e87"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -781,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.40"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b72fe77fd39e4bd3eaa4412fd299a0be6b3dfe9d2597e2f1c20beb968f41d17"
+checksum = "8be2398f326b7ba09815d0b403095f34dd708579220d099caae89be0b32137b2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [features]
 default = ["console_error_panic_hook"]
+benchmark = []
 
 [dependencies]
 async-std = { version = "=1.6.0", features = ["unstable"] }
@@ -17,8 +18,8 @@ flatbuffers = "0.6.1"
 futures = "0.3.5"
 js-sys = "0.3.40"
 lazy_static = "1.4.0"
-nanoserde = "0.1"
 log = "0.4"
+nanoserde = "0.1"
 sha2 = "0.8.1"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.13"
@@ -27,6 +28,7 @@ wee_alloc = "0.4.5"
 [dev-dependencies]
 async-std = { version = "=1.6.0", features = ["attributes", "unstable"] }
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }
+wasm-bench = { path = "crates/bench" }
 wasm-bindgen-test = "0.3.0"
 
 [dependencies.web-sys]
@@ -34,7 +36,6 @@ version = "0.3.40"
 features = [
     "console",
     "DomException",
-    "Window",
     "IdbDatabase",
     "IdbFactory",
     "IdbObjectStore",
@@ -42,6 +43,8 @@ features = [
     "IdbTransaction",
     "IdbTransactionMode",
     "IdbVersionChangeEvent",
+    "Performance",
+    "Window",
 ]
 
 [lib]

--- a/crates/bench-macro/Cargo.toml
+++ b/crates/bench-macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wasm-bench-macro"
+version = "0.1.0"
+authors = ["Rocicorp <replicache@roci.dev>"]
+edition = "2018"
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+
+[lib]
+proc-macro = true

--- a/crates/bench-macro/src/lib.rs
+++ b/crates/bench-macro/src/lib.rs
@@ -18,7 +18,7 @@ pub fn wasm_bench(
     while let Some(_) = attr.next() {
         match &attr.next() {
             Some(proc_macro::TokenTree::Punct(op)) if op.as_char() == ',' => {}
-            Some(_) => panic!("malformed `#[wasm_bindgen_test]` attribute"),
+            Some(_) => panic!("malformed `#[wasm_bench]` attribute"),
             None => break,
         }
     }

--- a/crates/bench-macro/src/lib.rs
+++ b/crates/bench-macro/src/lib.rs
@@ -1,0 +1,86 @@
+//! See the README for `wasm-bindgen-test` for a bit more info about what's
+//! going on here.
+
+extern crate proc_macro;
+
+use proc_macro2::*;
+use quote::quote;
+use std::sync::atomic::*;
+
+static CNT: AtomicUsize = AtomicUsize::new(0);
+
+#[proc_macro_attribute]
+pub fn wasm_bench(
+    attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let mut attr = attr.into_iter();
+    while let Some(_) = attr.next() {
+        match &attr.next() {
+            Some(proc_macro::TokenTree::Punct(op)) if op.as_char() == ',' => {}
+            Some(_) => panic!("malformed `#[wasm_bindgen_test]` attribute"),
+            None => break,
+        }
+    }
+
+    let mut body = TokenStream::from(body).into_iter();
+
+    // Skip over other attributes to `fn #ident ...`, and extract `#ident`
+    let mut leading_tokens = Vec::new();
+    while let Some(token) = body.next() {
+        leading_tokens.push(token.clone());
+        if let TokenTree::Ident(token) = token {
+            if token == "fn" {
+                break;
+            }
+        }
+    }
+    let ident = find_ident(&mut body).expect("expected a function name");
+
+    // We generate a `#[no_mangle]` with a known prefix so the test harness can
+    // later slurp up all of these functions and pass them as arguments to the
+    // main test harness. This is the entry point for all tests.
+    let name = format!("__wbgt_{}_{}", ident, CNT.fetch_add(1, Ordering::SeqCst));
+    let name = Ident::new(&name, Span::call_site());
+    let wrapper_name = Ident::new(&format!("{}_wrapper", ident), Span::call_site());
+    let mut tokens = Vec::<TokenTree>::new();
+    tokens.extend(
+        (quote! {
+            #[no_mangle]
+            pub extern "C" fn #name(cx: &::wasm_bindgen_test::__rt::Context) {
+                let test_name = concat!(module_path!(), "::", stringify!(#ident));
+                crate::wasm::init_console_log();
+                cx.execute_async(test_name, #wrapper_name);
+            }
+
+            async fn #wrapper_name() {
+                let mut module_path = module_path!();
+                let name: String = stringify!(#ident).into();
+                let index = module_path.find("::").unwrap();
+                module_path = &module_path[index + 2..];
+                let test_name = match module_path.find("::") {
+                    Some(index) => format!("{}::{}", &module_path[index + 2..], name),
+                    None => name,
+                };
+                benchmark(&test_name, #ident).await;
+            }
+        })
+        .into_iter(),
+    );
+
+    tokens.extend(leading_tokens);
+    tokens.push(ident.into());
+    tokens.extend(body);
+
+    tokens.into_iter().collect::<TokenStream>().into()
+}
+
+fn find_ident(iter: &mut token_stream::IntoIter) -> Option<Ident> {
+    match iter.next()? {
+        TokenTree::Ident(i) => Some(i),
+        TokenTree::Group(g) if g.delimiter() == Delimiter::None => {
+            find_ident(&mut g.stream().into_iter())
+        }
+        _ => None,
+    }
+}

--- a/crates/bench-macro/src/lib.rs
+++ b/crates/bench-macro/src/lib.rs
@@ -1,5 +1,29 @@
-//! See the README for `wasm-bindgen-test` for a bit more info about what's
-//! going on here.
+// This source file is based on
+// https://github.com/rustwasm/wasm-bindgen/blob/master/crates/test/src/lib.rs,
+// which is Copyright (c) 2014 Alex Crichton, and is dual licensed under the
+// MIT and Apache licenses. Various changes have been made to adapt that code
+// to the use case here of supporting asynchronous benchmarks under wasm, and
+// all such changes are copyrighted and licensed separately.
+//
+// Text of the MIT license from wasm-bindgen, for completeness:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 
 extern crate proc_macro;
 

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "wasm-bench"
+version = "0.1.0"
+authors = ["Rocicorp <replicache@roci.dev>"]
+edition = "2018"
+
+[dependencies]
+log = "0.4"
+wasm-bench-macro = { path = "../bench-macro" }
+web-sys = "0.3.42"
+
+[lib]
+test = false

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -1,0 +1,120 @@
+use core::future::Future;
+use log::error;
+use std::cmp;
+pub use wasm_bench_macro::wasm_bench;
+
+fn now_nanos() -> u64 {
+    let window = web_sys::window().expect("should have a window in this context");
+    let performance = window
+        .performance()
+        .expect("performance should be available");
+    return (performance.now() * 1e6) as u64;
+}
+
+pub struct Bench {
+    iterations: u64,
+    ns_start: u64, // Non-zero iff timer is currently running.
+    ns_elapsed: u64,
+    pub bytes: u64,
+}
+
+impl Bench {
+    fn new() -> Bench {
+        Bench {
+            iterations: 0,
+            ns_start: 0,
+            ns_elapsed: 0,
+            bytes: 0,
+        }
+    }
+
+    pub fn iterations(&self) -> u64 {
+        self.iterations
+    }
+
+    pub fn ns_elapsed(&self) -> u64 {
+        self.ns_elapsed
+    }
+
+    pub fn ns_per_iter(&self) -> u64 {
+        if self.iterations == 0 {
+            0
+        } else {
+            self.ns_elapsed() / cmp::max(self.iterations, 1)
+        }
+    }
+
+    pub fn start_timer(&mut self) {
+        self.ns_start = now_nanos();
+    }
+
+    pub fn stop_timer(&mut self) {
+        let now = now_nanos();
+        self.ns_elapsed += now - self.ns_start;
+        self.ns_start = 0;
+    }
+
+    pub fn reset_timer(&mut self) {
+        self.ns_elapsed = 0;
+    }
+}
+
+// Simplified workaround for async function pointers taking a reference from
+// https://github.com/rustasync/team/issues/19#issuecomment-515051308.
+pub trait AsyncFn1<A0> {
+    type Output;
+    type Future: Future<Output = Self::Output>;
+    fn call(&self, a0: A0) -> Self::Future;
+}
+
+impl<A0, F, Fut> AsyncFn1<A0> for F
+where
+    F: Fn(A0) -> Fut,
+    Fut: Future,
+{
+    type Output = Fut::Output;
+    type Future = Fut;
+    fn call(&self, a0: A0) -> Self::Future {
+        self(a0)
+    }
+}
+
+pub async fn benchmark<F>(name: &str, f: F)
+where
+    F: for<'a> AsyncFn1<&'a mut Bench, Output = ()>,
+{
+    const GOAL_NS: u64 = 1_000_000_000;
+    let mut b = Bench::new();
+
+    // Loop based on https://golang.org/src/testing/benchmark.go's launch().
+    let mut n = 1;
+
+    while b.ns_elapsed() < GOAL_NS {
+        let prev_n = n;
+        let prev_ns = cmp::max(b.ns_elapsed(), 1);
+
+        n = GOAL_NS * prev_n / prev_ns;
+        n += n / 5;
+        n = cmp::min(n, 100 * prev_n);
+        n = cmp::max(n, prev_n + 1);
+        n = cmp::min(n, 1e9 as u64);
+        b.iterations = n;
+        b.start_timer();
+        b.reset_timer();
+        f.call(&mut b).await;
+        b.stop_timer();
+    }
+
+    let mut extra: String = "".into();
+    if b.bytes != 0 {
+        let mbps = ((b.bytes * b.iterations) as f64 / 1e6) / (b.ns_elapsed() as f64 / 1e9);
+        extra = format!(" {:.2} MB/s", mbps);
+    }
+    error!(
+        "{} {} {} ns/iter{}",
+        name,
+        b.iterations,
+        b.ns_per_iter(),
+        extra
+    );
+}

--- a/src/benches/idbstore.rs
+++ b/src/benches/idbstore.rs
@@ -1,0 +1,98 @@
+use crate::kv::idbstore::IdbStore;
+use crate::kv::Store;
+use rand::Rng;
+use wasm_bench::*;
+
+fn rand_bytes(len: usize) -> Vec<u8> {
+    (0..len).map(|_| rand::random::<u8>()).collect()
+}
+
+fn rand_string(len: usize) -> String {
+    let mut rng = rand::thread_rng();
+    std::iter::repeat(())
+        .map(|_| rng.sample(rand::distributions::Alphanumeric))
+        .take(len)
+        .collect()
+}
+
+#[wasm_bench]
+async fn read1x256(b: &mut Bench) {
+    read1x(b, 256).await
+}
+
+#[wasm_bench]
+async fn read1x1024(b: &mut Bench) {
+    read1x(b, 1 * 1024).await
+}
+
+#[wasm_bench]
+async fn read1x4096(b: &mut Bench) {
+    read1x(b, 4 * 1024).await
+}
+
+#[wasm_bench]
+async fn read1x16384(b: &mut Bench) {
+    read1x(b, 16 * 1024).await
+}
+
+#[wasm_bench]
+async fn read1x65536(b: &mut Bench) {
+    read1x(b, 64 * 1024).await
+}
+
+async fn read1x(b: &mut Bench, size: u64) {
+    let store = IdbStore::new(&rand_string(12)[..]).await.unwrap().unwrap();
+    let key = rand_string(12);
+    let wt = store.write().await.unwrap();
+    wt.put(&key, &rand_bytes(size as usize)).await.unwrap();
+    wt.commit().await.unwrap();
+
+    let rt = store.read().await.unwrap();
+    b.bytes = size;
+    let n = b.iterations();
+    b.reset_timer();
+    for _ in 0..n {
+        rt.get(&key).await.unwrap();
+    }
+}
+
+#[wasm_bench]
+async fn write1x256(b: &mut Bench) {
+    write(b, 1, 256).await
+}
+
+#[wasm_bench]
+async fn write1x4096(b: &mut Bench) {
+    write(b, 1, 4 * 1024).await
+}
+
+#[wasm_bench]
+async fn write4x4096(b: &mut Bench) {
+    write(b, 4, 4 * 1024).await
+}
+
+#[wasm_bench]
+async fn write16x4096(b: &mut Bench) {
+    write(b, 16, 4 * 1024).await
+}
+
+#[wasm_bench]
+async fn write1x65536(b: &mut Bench) {
+    write(b, 1, 64 * 1024).await
+}
+
+async fn write(b: &mut Bench, writes: u32, size: u64) {
+    let store = IdbStore::new(&rand_string(12)[..]).await.unwrap().unwrap();
+    let key = rand_string(12);
+
+    b.bytes = writes as u64 * size;
+    let n = b.iterations();
+    b.reset_timer();
+    for _ in 0..n {
+        let wt = store.write().await.unwrap();
+        for _ in 0..writes {
+            wt.put(&key, &rand_bytes(size as usize)).await.unwrap();
+        }
+        wt.commit().await.unwrap();
+    }
+}

--- a/src/benches/mod.rs
+++ b/src/benches/mod.rs
@@ -1,0 +1,18 @@
+use wasm_bench::*;
+use wasm_bindgen_test::*;
+
+mod idbstore;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bench]
+async fn performance_now(b: &mut Bench) {
+    let window = web_sys::window().expect("should have a window in this context");
+    let performance = window
+        .performance()
+        .expect("performance should be available");
+
+    for _ in 0..b.iterations() {
+        || -> u64 { (performance.now() * 1e6) as u64 }();
+    }
+}

--- a/src/benches/mod.rs
+++ b/src/benches/mod.rs
@@ -12,7 +12,8 @@ async fn performance_now(b: &mut Bench) {
         .performance()
         .expect("performance should be available");
 
-    for _ in 0..b.iterations() {
+    let n = b.iterations();
+    for _ in 0..n {
         || -> u64 { (performance.now() * 1e6) as u64 }();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,6 @@ pub mod kv;
 mod kv;
 
 mod prolly;
+
+#[cfg(feature = "benchmark")]
+pub mod benches;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -45,12 +45,16 @@ pub async fn dispatch(db_name: String, rpc: String, args: String) -> Result<Stri
 
 static INIT: Once = Once::new();
 
-fn init_panic_hook() {
-    #[cfg(feature = "console_error_panic_hook")]
-    console_error_panic_hook::set_once();
+pub fn init_console_log() {
     INIT.call_once(|| {
         if let Err(e) = console_log::init_with_level(log::Level::Info) {
             web_sys::console::error_1(&format!("Error registering console_log: {}", e).into());
         }
     });
+}
+
+fn init_panic_hook() {
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+    init_console_log();
 }

--- a/tool/benchmark
+++ b/tool/benchmark
@@ -46,6 +46,10 @@ import sys
 lines = sys.stdin.readlines()
 lines.reverse()  # Restore tests to the order their functions appear in.
 
+if not lines:
+    print("No benchmarks were selected.")
+    sys.exit(0)
+
 # Figure out the maximum width of each column.
 cols = {}
 for l in lines:

--- a/tool/benchmark
+++ b/tool/benchmark
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# Script to run WebAssembly benchmark tests within a browser.
+
+PREFIX=benches
+
+for i in "$@"; do
+    case $i in
+    --help)
+        echo "$0 [--help] [<test prefix>]"
+        exit 0
+        ;;
+    *)
+        PREFIX=$1
+        ;;
+esac
+done
+
+WASM_BINDGEN_TEST_TIMEOUT=60  # Raise as more benchmarks are added.
+
+wasm-pack test --release --chrome --headless -- --lib $PREFIX \
+    --features benchmark \
+    | grep "ns/iter" \
+    | python3 -c '
+import sys
+
+lines = sys.stdin.readlines()
+lines.reverse()  # Restore tests to the order their functions appear in.
+
+# Figure out the maximum width of each column.
+cols = {}
+for l in lines:
+    for i, word in enumerate(l.split()):
+        cols[i] = max(len(word), cols.get(i, 0))
+
+# Make non-unit columns have an extra width for readability.
+for i in range(2, len(cols), 2):
+    cols[i] += 1
+
+# Assemble format string, and format each line with it.
+format = "%%-%ds" % (cols[0] + 1)
+format += " ".join("%%%ds" % i for i in list(cols.values())[1:])
+for l in lines:
+    words = l.split()
+    words += [""] * (len(cols) - len(words))
+    print(format % tuple(words))'

--- a/tool/benchmark
+++ b/tool/benchmark
@@ -6,8 +6,8 @@ PREFIX=benches
 
 for i in "$@"; do
     case $i in
-    --help)
-        echo "$0 [--help] [<test prefix>]"
+    -h|--help)
+        echo "`basename -- $0` [--help] [<test prefix>]"
         exit 0
         ;;
     *)
@@ -16,7 +16,26 @@ for i in "$@"; do
 esac
 done
 
-WASM_BINDGEN_TEST_TIMEOUT=60  # Raise as more benchmarks are added.
+SYSTEM=`uname -s`
+
+if [ $SYSTEM = 'Darwin' ]; then
+    HW=`system_profiler SPHardwareDataType`
+    STORAGE=`system_profiler SPStorageDataType`
+    CPU=`echo "$HW" | grep Processor\ Name: | cut -d:  -f2-`
+    SPEED=`echo "$HW" | grep Speed: | cut -d: -f2-`
+    MEM=`echo "$HW" | grep Memory: | cut -d: -f2-`
+    DISK_TYPE=`echo "$STORAGE" | grep Medium\ Type: | head -1 | cut -d: -f2-`
+    DISK_SIZE=`echo "$STORAGE" | grep Capacity: | head -1 | cut -d: -f2- | cut -d\  -f2-3`
+
+    echo "Hardware:$CPU$SPEED,$MEM RAM, $DISK_SIZE$DISK_TYPE"
+elif [ $SYSTEM = 'Linux' ]; then
+    LSCPU=`lscpu`
+    CPU=`echo "$LSCPU" | grep Model\ name: | cut -d\  -f3- | sed -e 's/^[[:space:]]*//'`
+    CORES=`echo "$LSCPU" | grep CPU\(s\): | cut -d\  -f2- | sed -e 's/^[[:space:]]*//'`
+    echo "Hardware: $CPU ($CORES cores)"
+fi
+
+export WASM_BINDGEN_TEST_TIMEOUT=120  # Raise as more benchmarks are added.
 
 wasm-pack test --release --chrome --headless -- --lib $PREFIX \
     --features benchmark \
@@ -34,7 +53,7 @@ for l in lines:
         cols[i] = max(len(word), cols.get(i, 0))
 
 # Make non-unit columns have an extra width for readability.
-for i in range(2, len(cols), 2):
+for i in range(0, len(cols), 2):
     cols[i] += 1
 
 # Assemble format string, and format each line with it.


### PR DESCRIPTION
Benchmarks are defined like so:

```
async fn example(b: &mut Bench) {
    ...setup...

    // Optional: set bytes per iterations to have throughput reported.
    b.bytes = 4096;

    let n = b.iterations();
    for _ in 0..n {
        ...code for one benchmark iteration...
    }
}
```

Example runs:

```
% ./tool/benchmark -h
benchmark [--help] [<test prefix>]

% time ./tool/benchmark 2> /dev/null
idbstore::read1x1024     11778     99191 ns/iter   10.32 MB/s
idbstore::read1x4096      9361    123176 ns/iter   33.25 MB/s
idbstore::read1x16384     6949    160272 ns/iter  102.23 MB/s
idbstore::read1x65536     1598    724580 ns/iter   90.45 MB/s
idbstore::write1x256       130   9056923 ns/iter    0.03 MB/s
idbstore::write1x4096      123   9769471 ns/iter    0.42 MB/s
idbstore::write4x4096      121  10164752 ns/iter    1.61 MB/s
idbstore::write16x4096     100  11108750 ns/iter    5.90 MB/s
idbstore::write1x65536     100  46842900 ns/iter    1.40 MB/s
performance_now        6255864       181 ns/iter
./tool/benchmark  16.31s user 3.02s system 69% cpu 27.914 total

% time ./tool/benchmark idbstore::read 2> /dev/null
idbstore::read1x256   11518   96580 ns/iter    2.65 MB/s
idbstore::read1x1024  11391  102028 ns/iter   10.04 MB/s
idbstore::read1x4096   9464  120978 ns/iter   33.86 MB/s
idbstore::read1x16384  7366  151667 ns/iter  108.03 MB/s
idbstore::read1x65536  1594  679372 ns/iter   96.47 MB/s
./tool/benchmark idbstore::read 2> /dev/null  3.32s user 1.33s system 52% cpu 8.790 total
```

Notes:

o crates/bench and crates/bench-macro implement the framework. This
  directory structure comes from rustwasm/wasm-bindgen, and is necessary
  because procedural macros (e.g., `#[wasm_bench]`) may only exist in a
  "proc-macro" crate, which is then not allowed to export anything apart
  from such macros.
o The content of crates/bench-macro is based on
  https://github.com/rustwasm/wasm-bindgen/blob/master/crates/test-macro/src/lib.rs,
  with moderate modifications for our use case.
o The content of crates/bench is based on a combination of Bencher from
  https://github.com/rust-lang/libtest/blob/master/libtest/lib.rs#L179
  and Go's benchmark algorithm from
  https://github.com/golang/go/blob/master/src/testing/benchmark.go#L295.
o This uses 'wasm-pack test' under the hood to launch a headless browser
  and facilitate benchmark selection.
o This adds zero (0) bytes to the release build!