### PR TITLE
Add benchmarks for db-level dispatch calls.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +701,7 @@ name = "wasm-bench"
 version = "0.1.0"
 dependencies = [
  "log",
+ "thousands",
  "wasm-bench-macro",
  "web-sys",
 ]

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
+thousands = "0.2.0"
 wasm-bench-macro = { path = "../bench-macro" }
 web-sys = "0.3.42"
 

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -1,6 +1,7 @@
 use core::future::Future;
 use log::error;
 use std::cmp;
+use thousands::Separable;
 pub use wasm_bench_macro::wasm_bench;
 
 fn now_nanos() -> u64 {
@@ -114,7 +115,7 @@ where
         "{} {} {} ns/iter{}",
         name,
         b.iterations,
-        b.ns_per_iter(),
+        b.ns_per_iter().separate_with_commas(),
         extra
     );
 }

--- a/src/benches/dispatch.rs
+++ b/src/benches/dispatch.rs
@@ -1,0 +1,147 @@
+use crate::benches::{random_bytes, random_string};
+use crate::dispatch::*;
+use crate::kv::idbstore::IdbStore;
+use crate::kv::Store;
+use wasm_bench::*;
+
+async fn opendb() -> String {
+    let dbname = random_string(12);
+    dispatch(dbname.clone(), "open".into(), "".into())
+        .await
+        .unwrap();
+    dbname
+}
+
+async fn eval(code: &str) {
+    wasm_bindgen_futures::JsFuture::from(js_sys::Promise::resolve(&js_sys::eval(code).unwrap()))
+        .await
+        .unwrap();
+}
+
+#[wasm_bench]
+async fn has(b: &mut Bench) {
+    let dbname = opendb().await;
+
+    let store = IdbStore::new(&dbname).await.unwrap().unwrap();
+    let wt = store.write().await.unwrap();
+    for i in 0..b.iterations() {
+        if i % 2 == 0 {
+            wt.put(&format!("{}", i), &random_bytes(512)).await.unwrap();
+        }
+    }
+    wt.commit().await.unwrap();
+
+    b.reset_timer();
+    eval(&format!(
+        "
+        (async _ => {{
+            for (let i = 0; i < {}; i++) {{
+                await dispatch(\"{}\", \"has\", '{{\"key\": \"' + i + '\"}}');
+            }}
+        }})()",
+        b.iterations(),
+        dbname
+    ))
+    .await;
+}
+
+#[wasm_bench]
+async fn get1024(b: &mut Bench) {
+    get(b, 1024).await
+}
+
+#[wasm_bench]
+async fn get4096(b: &mut Bench) {
+    get(b, 4 * 1024).await
+}
+
+#[wasm_bench]
+async fn get16384(b: &mut Bench) {
+    get(b, 16 * 1024).await
+}
+
+async fn get(b: &mut Bench, size: u64) {
+    let dbname = opendb().await;
+
+    let store = IdbStore::new(&dbname).await.unwrap().unwrap();
+    let wt = store.write().await.unwrap();
+    for i in 0..b.iterations() {
+        if i % 2 == 0 {
+            wt.put(&format!("{}", i), &random_bytes(size))
+                .await
+                .unwrap();
+        }
+    }
+    wt.commit().await.unwrap();
+
+    b.bytes = size;
+    b.reset_timer();
+    eval(&format!(
+        "
+        (async _ => {{
+            for (let i = 0; i < {}; i++) {{
+                await dispatch(\"{}\", \"get\", '{{\"key\": \"' + i + '\"}}');
+            }}
+        }})()",
+        b.iterations(),
+        dbname
+    ))
+    .await;
+}
+
+#[wasm_bench]
+async fn put1024(b: &mut Bench) {
+    put(b, 1024).await
+}
+
+#[wasm_bench]
+async fn put4096(b: &mut Bench) {
+    put(b, 4 * 1024).await
+}
+
+#[wasm_bench]
+async fn put16384(b: &mut Bench) {
+    put(b, 16 * 1024).await
+}
+
+// TODO(nate): Expand to multiple puts in a transaction once that's possible.
+async fn put(b: &mut Bench, size: u64) {
+    let dbname = opendb().await;
+
+    b.bytes = size;
+    b.reset_timer();
+    eval(&format!(
+        "
+        (async _ => {{
+            var array = new Uint8Array({});
+            for (let i = 0; i < {}; i++) {{
+                window.crypto.getRandomValues(array);
+                await dispatch(\"{}\", \"put\", '{{\"key\": \"' + i + '\", \"value\": \"' + array.toString().substring(0, {}) + '\"}}');
+            }}
+        }})()",
+        size,
+        b.iterations(),
+        dbname,
+        size
+    )).await
+}
+
+#[wasm_bench]
+async fn random4096(b: &mut Bench) {
+    let size = 4096;
+    b.bytes = size;
+    eval(&format!(
+        "
+        (async _ => {{
+            var array = new Uint8Array({});
+            for (let i = 0; i < {}; i++) {{
+                window.crypto.getRandomValues(array);
+                let bytes = array.toString().substring(0, {});
+            }}
+        }})()",
+        size,
+        b.iterations(),
+        size,
+    ))
+    .await
+}

--- a/src/benches/idbstore.rs
+++ b/src/benches/idbstore.rs
@@ -1,20 +1,8 @@
+use crate::benches::{random_bytes, random_string};
 use crate::kv::idbstore::IdbStore;
 use crate::kv::Store;
 use futures::stream::{FuturesUnordered, StreamExt};
-use rand::Rng;
 use wasm_bench::*;
-
-fn rand_bytes(len: usize) -> Vec<u8> {
-    (0..len).map(|_| rand::random::<u8>()).collect()
-}
-
-fn rand_string(len: usize) -> String {
-    let mut rng = rand::thread_rng();
-    std::iter::repeat(())
-        .map(|_| rng.sample(rand::distributions::Alphanumeric))
-        .take(len)
-        .collect()
-}
 
 #[wasm_bench]
 async fn read1x256(b: &mut Bench) {
@@ -42,14 +30,17 @@ async fn read1x65536(b: &mut Bench) {
 }
 
 async fn read1x(b: &mut Bench, size: u64) {
-    let store = IdbStore::new(&rand_string(12)[..]).await.unwrap().unwrap();
+    let store = IdbStore::new(&random_string(12)[..])
+        .await
+        .unwrap()
+        .unwrap();
 
     let n = b.iterations() as usize;
     let mut keys = Vec::with_capacity(n);
     for _ in 0..n {
-        keys.push(rand_string(12));
+        keys.push(random_string(12));
     }
-    let bytes = rand_bytes(size as usize);
+    let bytes = random_bytes(size);
 
     let wt = store.write().await.unwrap();
     for i in 0..n {
@@ -81,14 +72,17 @@ async fn read64x4096(b: &mut Bench) {
 }
 
 async fn read(b: &mut Bench, concurrency: usize, size: u64) {
-    let store = IdbStore::new(&rand_string(12)[..]).await.unwrap().unwrap();
+    let store = IdbStore::new(&random_string(12)[..])
+        .await
+        .unwrap()
+        .unwrap();
 
     let n = b.iterations() as usize;
     let mut keys = Vec::with_capacity(n);
     for _ in 0..n {
-        keys.push(rand_string(12));
+        keys.push(random_string(12));
     }
-    let bytes = rand_bytes(size as usize);
+    let bytes = random_bytes(size);
 
     let wt = store.write().await.unwrap();
     for i in 0..n {
@@ -147,13 +141,16 @@ async fn write1x65536(b: &mut Bench) {
 }
 
 async fn write(b: &mut Bench, writes: usize, size: u64) {
-    let store = IdbStore::new(&rand_string(12)[..]).await.unwrap().unwrap();
+    let store = IdbStore::new(&random_string(12)[..])
+        .await
+        .unwrap()
+        .unwrap();
     let mut n = (b.iterations() as usize / writes) * writes;
     let mut keys = Vec::with_capacity(n);
     for _ in 0..n {
-        keys.push(rand_string(12));
+        keys.push(random_string(12));
     }
-    let bytes = rand_bytes(size as usize);
+    let bytes = random_bytes(size);
 
     b.bytes = writes as u64 * size;
     n /= writes;

--- a/src/benches/mod.rs
+++ b/src/benches/mod.rs
@@ -1,9 +1,23 @@
+use rand::Rng;
 use wasm_bench::*;
 use wasm_bindgen_test::*;
 
+mod dispatch;
 mod idbstore;
 
 wasm_bindgen_test_configure!(run_in_browser);
+
+fn random_bytes(len: u64) -> Vec<u8> {
+    (0..len).map(|_| rand::random::<u8>()).collect()
+}
+
+fn random_string(len: usize) -> String {
+    let mut rng = rand::thread_rng();
+    std::iter::repeat(())
+        .map(|_| rng.sample(rand::distributions::Alphanumeric))
+        .take(len)
+        .collect()
+}
 
 #[wasm_bench]
 async fn performance_now(b: &mut Bench) {


### PR DESCRIPTION
These are novel in that the benchmark loop executes in JS space and each
iteration calls into Rust and transfers the response back to JS.

Example run:

```
% ./tool/benchmark dispatch
Hardware: 8-Core Intel Core i9 2.4 GHz, 32 GB RAM, 1 TB SSD

dispatch::has           483   2,141,490 ns/iter
dispatch::get1024       468   2,229,690 ns/iter   0.46 MB/s
dispatch::get4096       459   2,273,355 ns/iter   1.80 MB/s
dispatch::get16384      438   2,463,367 ns/iter   6.65 MB/s
dispatch::put1024       100  23,429,150 ns/iter   0.04 MB/s
dispatch::put4096       100  35,972,949 ns/iter   0.11 MB/s
dispatch::put16384      100  57,210,150 ns/iter   0.29 MB/s
dispatch::random4096  10855     108,412 ns/iter  37.78 MB/s
```