### PR TITLE
Quick benchmark of noop dispatch calls from JS.

### DIFF
--- a/src/benches/dispatch.rs
+++ b/src/benches/dispatch.rs
@@ -19,6 +19,25 @@ async fn eval(code: &str) {
 }
 
 #[wasm_bench]
+async fn noop(b: &mut Bench) {
+    let dbname = opendb().await;
+
+    let _ = IdbStore::new(&dbname).await.unwrap().unwrap();
+    b.reset_timer();
+    eval(&format!(
+        "
+        (async _ => {{
+            for (let i = 0; i < {}; i++) {{
+                await dispatch('{}', 'open', '');
+            }}
+        }})()",
+        b.iterations(),
+        dbname
+    ))
+    .await;
+}
+
+#[wasm_bench]
 async fn has(b: &mut Bench) {
     let dbname = opendb().await;
 


### PR DESCRIPTION
So, <= 4 microseconds over overhead per call from JS to dispatch.

% ./tool/benchmark dispatch::noop
Hardware: 8-Core Intel Core i9 2.4 GHz, 32 GB RAM, 1 TB SSD
dispatch::noop  306020  3,911 ns/iter