### PR TITLE
Cleanups--tighten dead_code, and remove one mut.

### DIFF
--- a/src/dag/store.rs
+++ b/src/dag/store.rs
@@ -3,17 +3,16 @@ use super::write::Write;
 use super::Result;
 use crate::kv;
 
-#[allow(dead_code)]
 pub struct Store {
     kv: Box<dyn kv::Store>,
 }
 
-#[allow(dead_code)]
 impl Store {
     pub fn new(kv: Box<dyn kv::Store>) -> Store {
         Store { kv }
     }
 
+    #[allow(dead_code)]
     pub async fn read(&self) -> Result<OwnedRead<'_>> {
         Ok(OwnedRead::new(self.kv.read().await?))
     }

--- a/src/dag/write.rs
+++ b/src/dag/write.rs
@@ -3,12 +3,10 @@ use super::key::Key;
 use super::{read, Result};
 use crate::kv;
 
-#[allow(dead_code)]
 pub struct Write<'a> {
     kvw: Box<dyn kv::Write + 'a>,
 }
 
-#[allow(dead_code)]
 impl<'a> Write<'_> {
     pub fn new(kvw: Box<dyn kv::Write + 'a>) -> Write {
         Write { kvw }
@@ -41,6 +39,7 @@ impl<'a> Write<'_> {
         Ok(self.kvw.commit().await?)
     }
 
+    #[allow(dead_code)]
     pub async fn rollback(self) -> Result<()> {
         Ok(self.kvw.rollback().await?)
     }

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -48,7 +48,6 @@ impl Hash {
         }
     }
 
-    #[allow(dead_code)]
     pub fn of(data: &[u8]) -> Hash {
         let mut hasher = Sha512::new();
         hasher.input(data);

--- a/src/kv/memstore.rs
+++ b/src/kv/memstore.rs
@@ -138,7 +138,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_store_trait() -> std::result::Result<(), StoreError> {
-        let mut ms = MemStore::new();
+        let ms = MemStore::new();
 
         // Test put/has/get, which use read() and write() for one-shot txs.
         assert!(!ms.has("foo").await?);
@@ -163,7 +163,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_read_transaction() -> std::result::Result<(), StoreError> {
-        let mut ms = MemStore::new();
+        let ms = MemStore::new();
         ms.put("k1", b"v1").await?;
 
         let rt = ms.read().await?;
@@ -175,7 +175,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_write_transaction() -> std::result::Result<(), StoreError> {
-        let mut ms = MemStore::new();
+        let ms = MemStore::new();
         ms.put("k1", b"v1").await?;
         ms.put("k2", b"v2").await?;
 

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -24,7 +24,7 @@ pub trait Store {
     async fn read<'a>(&'a self) -> Result<Box<dyn Read + 'a>>;
     async fn write<'a>(&'a self) -> Result<Box<dyn Write + 'a>>;
 
-    async fn put(&mut self, key: &str, value: &[u8]) -> Result<()> {
+    async fn put(&self, key: &str, value: &[u8]) -> Result<()> {
         let wt = self.write().await?;
         wt.put(key, value).await?;
         Ok(wt.commit().await?)

--- a/src/prolly/buzhash.rs
+++ b/src/prolly/buzhash.rs
@@ -45,7 +45,6 @@ pub struct BuzHash {
     overflow: bool,
 }
 
-#[allow(dead_code)]
 impl BuzHash {
     pub fn new(n: u32) -> BuzHash {
         let bshiftn = n % 32;

--- a/src/prolly/map.rs
+++ b/src/prolly/map.rs
@@ -12,7 +12,6 @@ use std::iter::{Iterator, Peekable};
 
 type Hash = String;
 
-#[allow(dead_code)]
 pub struct Map {
     base: Option<Leaf>,
     pending: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
@@ -48,7 +47,6 @@ impl From<dag::Error> for FlushError {
     }
 }
 
-#[allow(dead_code)]
 impl Map {
     pub fn new() -> Map {
         Map {
@@ -80,6 +78,7 @@ impl Map {
         self.pending.insert(key, Some(val));
     }
 
+    #[allow(dead_code)]
     pub fn del(&mut self, key: Vec<u8>) {
         self.pending.insert(key, None);
     }

--- a/src/prolly/mod.rs
+++ b/src/prolly/mod.rs
@@ -7,7 +7,6 @@ mod map;
 
 pub use map::{FlushError, LoadError, Map};
 
-#[allow(dead_code)]
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct Entry<'a> {
     pub key: &'a [u8],


### PR DESCRIPTION
Removes #[allow(dead_code)] in several places, and tightens check in a
few others to apply to a single method rather than a whole impl.

No semantic changes.