### PR TITLE
One technique for OpenTransaction.

### DIFF
--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -1,0 +1,256 @@
+use super::dispatch::Request;
+use super::types::*;
+use crate::dag;
+use crate::db;
+use async_fn::AsyncFn2;
+use async_std::stream::StreamExt;
+use async_std::sync::{Receiver, RecvError, RwLock};
+use futures::stream::futures_unordered::FuturesUnordered;
+use log::warn;
+use nanoserde::{DeJson, SerJson};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+lazy_static! {
+    static ref TRANSACTION_COUNTER: AtomicU32 = AtomicU32::new(1);
+}
+
+type TxnMap<'a> = RwLock<HashMap<u32, RwLock<db::Write<'a>>>>;
+
+fn deserialize<T: DeJson>(data: &str) -> Result<T, String> {
+    match DeJson::deserialize_json(data) {
+        Ok(v) => Ok(v),
+        Err(e) => Err(format!("InvalidJson({})", e)),
+    }
+}
+
+enum UnorderedResult {
+    Request(Result<Request, RecvError>),
+    Stop(),
+    None(),
+}
+
+async fn connection_future<'a, 'b>(
+    rx: &Receiver<Request>,
+    store: &'a dag::Store,
+    txns: &'b TxnMap<'a>,
+    request: Option<Request>,
+) -> UnorderedResult {
+    let req = match request {
+        None => return UnorderedResult::Request(rx.recv().await),
+        Some(v) => v,
+    };
+    match req.rpc.as_str() {
+        "has" => execute(do_has, txns, req).await,
+        "get" => execute(do_get, txns, req).await,
+        "put" => execute(do_put, txns, req).await,
+        "openTransaction" => do_open(store, txns, req).await,
+        "commitTransaction" => do_commit(txns, req).await,
+        "closeTransaction" => do_abort(txns, req).await,
+        "close" => {
+            req.response.send(Ok("".into())).await;
+            return UnorderedResult::Stop();
+        }
+        _ => {
+            req.response
+                .send(Err(format!("Unsupported rpc name {}", req.rpc)))
+                .await
+        }
+    };
+    UnorderedResult::None()
+}
+
+pub async fn process(store: dag::Store, rx: Receiver<Request>) {
+    let txns = RwLock::new(HashMap::new());
+    let mut futures = FuturesUnordered::new();
+    let mut recv = true;
+
+    futures.push(connection_future(&rx, &store, &txns, None));
+    while let Some(value) = futures.next().await {
+        if recv {
+            futures.push(connection_future(&rx, &store, &txns, None));
+        }
+        match value {
+            UnorderedResult::Request(value) => match value {
+                Err(why) => warn!("Dispatch loop recv failed: {}", why),
+                Ok(req) => {
+                    futures.push(connection_future(&rx, &store, &txns, Some(req)));
+                }
+            },
+            UnorderedResult::Stop() => recv = false,
+            UnorderedResult::None() => {}
+        }
+    }
+}
+
+async fn execute<T, F>(func: F, txns: &TxnMap<'_>, req: Request)
+where
+    T: DeJson + TransactionRequest,
+    F: for<'r, 's> AsyncFn2<&'r RwLock<db::Write<'s>>, T, Output = Result<String, String>>,
+{
+    let request: T = match deserialize(&req.data) {
+        Ok(v) => v,
+        Err(e) => return req.response.send(Err(e)).await,
+    };
+
+    let txn_id = request.transaction_id();
+    let txns = txns.read().await;
+    let txn = match txns.get(&txn_id) {
+        Some(v) => v,
+        None => {
+            return req
+                .response
+                .send(Err(format!("No transaction {}", txn_id)))
+                .await
+        }
+    };
+
+    req.response.send(func.call(txn, request).await).await;
+}
+
+async fn do_open<'a, 'b>(store: &'a dag::Store, txns: &'b TxnMap<'a>, req: Request) {
+    use OpenTransactionError::*;
+    let dag_write = store.write().await.map_err(DagWriteError).unwrap();
+    let write = db::Write::new_from_head("main", dag_write)
+        .await
+        .map_err(DBWriteError)
+        .unwrap();
+    let txn_id = TRANSACTION_COUNTER.fetch_add(1, Ordering::SeqCst);
+    txns.write().await.insert(txn_id, RwLock::new(write));
+    req.response
+        .send(Ok(SerJson::serialize_json(&OpenTransactionResponse {
+            transaction_id: txn_id,
+        })))
+        .await;
+}
+
+async fn do_commit(txns: &TxnMap<'_>, req: Request) {
+    let txn_id = match deserialize::<CommitTransactionRequest>(&req.data) {
+        Ok(v) => v.transaction_id,
+        Err(e) => return req.response.send(Err(e)).await,
+    };
+    let mut txns = txns.write().await;
+    let txn = match txns.remove(&txn_id) {
+        Some(v) => v,
+        None => {
+            return req
+                .response
+                .send(Err(format!("No such transaction {}", txn_id)))
+                .await;
+        }
+    };
+    let txn = txn.into_inner();
+    let response = txn
+        .commit(
+            "main",
+            "local-create-date",
+            "checksum",
+            42,
+            "foo",
+            b"bar",
+            None,
+        )
+        .await;
+    if let Err(e) = response {
+        req.response
+            .send(Err(format!("{:?}", CommitError::CommitError(e))))
+            .await;
+        return;
+    }
+    req.response
+        .send(Ok(SerJson::serialize_json(&CommitTransactionResponse {})))
+        .await;
+}
+
+async fn do_abort(txns: &TxnMap<'_>, req: Request) {
+    let request: CommitTransactionRequest = match DeJson::deserialize_json(&req.data) {
+        Ok(v) => v,
+        Err(e) => return req.response.send(Err(format!("InvalidJson({})", e))).await,
+    };
+    let txn_id = request.transaction_id;
+    if txns.write().await.remove(&txn_id).is_none() {
+        return req
+            .response
+            .send(Err(format!("No transaction {}", txn_id)))
+            .await;
+    };
+    req.response
+        .send(Ok(SerJson::serialize_json(&CommitTransactionResponse {})))
+        .await;
+}
+
+async fn do_has(txn: &RwLock<db::Write<'_>>, req: GetRequest) -> Result<String, String> {
+    Ok(SerJson::serialize_json(&GetResponse {
+        has: txn.read().await.has(req.key.as_bytes()),
+        value: None,
+    }))
+}
+
+async fn do_get(txn: &RwLock<db::Write<'_>>, req: GetRequest) -> Result<String, String> {
+    #[cfg(not(default))] // Not enabled in production.
+    if req.key.starts_with("sleep") {
+        use async_std::task::sleep;
+        use core::time::Duration;
+
+        match req.key[5..].parse::<u64>() {
+            Ok(ms) => {
+                sleep(Duration::from_millis(ms)).await;
+            }
+            Err(_) => log::error!("No sleep"),
+        }
+    }
+
+    let got = txn
+        .read()
+        .await
+        .get(req.key.as_bytes())
+        .map(|buf| String::from_utf8(buf.to_vec()));
+    if let Some(Err(e)) = got {
+        return Err(format!("{:?}", e));
+    }
+    let got = got.map(|r| r.unwrap());
+    Ok(SerJson::serialize_json(&GetResponse {
+        has: got.is_some(),
+        value: got,
+    }))
+}
+
+async fn do_put(txn: &RwLock<db::Write<'_>>, req: PutRequest) -> Result<String, String> {
+    txn.write()
+        .await
+        .put(req.key.as_bytes().to_vec(), req.value.into_bytes());
+    Ok("{}".into())
+}
+
+#[derive(Debug)]
+enum OpenTransactionError {
+    DagWriteError(dag::Error),
+    DBWriteError(db::NewError),
+}
+
+#[derive(Debug)]
+enum CommitError {
+    CommitError(db::CommitError),
+}
+
+trait TransactionRequest {
+    fn transaction_id(&self) -> u32;
+}
+
+impl TransactionRequest for CommitTransactionRequest {
+    fn transaction_id(&self) -> u32 {
+        self.transaction_id
+    }
+}
+
+impl TransactionRequest for GetRequest {
+    fn transaction_id(&self) -> u32 {
+        self.transaction_id
+    }
+}
+
+impl TransactionRequest for PutRequest {
+    fn transaction_id(&self) -> u32 {
+        self.transaction_id
+    }
+}

--- a/src/embed/dispatch.rs
+++ b/src/embed/dispatch.rs
@@ -1,22 +1,17 @@
-#![allow(clippy::redundant_pattern_matching)] // For derive(DeJson).
-
 use crate::dag;
-use crate::db;
+use crate::embed::connection;
 use crate::kv::idbstore::IdbStore;
-use async_fn::AsyncFn2;
 use async_std::sync::{channel, Receiver, Sender};
 use log::warn;
-use nanoserde::{DeJson, SerJson};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Mutex;
 use wasm_bindgen_futures::spawn_local;
 
-struct Request {
+pub struct Request {
     db_name: String,
-    rpc: String,
-    data: String,
-    response: Sender<Response>,
+    pub rpc: String,
+    pub data: String,
+    pub response: Sender<Response>,
 }
 
 type Response = Result<String, String>;
@@ -27,272 +22,40 @@ lazy_static! {
         spawn_local(dispatch_loop(rx));
         Mutex::new(tx)
     };
-    static ref TRANSACTION_COUNTER: AtomicU32 = AtomicU32::new(1);
 }
+
+type ConnMap = HashMap<String, Sender<Request>>;
 
 async fn dispatch_loop(rx: Receiver<Request>) {
-    let mut dispatcher = Dispatcher {
-        connections: HashMap::new(),
-    };
+    let mut conns: ConnMap = HashMap::new();
 
     loop {
-        match rx.recv().await {
-            Err(why) => warn!("Dispatch loop recv failed: {}", why),
-            Ok(req) => {
-                let response = match req.rpc.as_str() {
-                    "open" => Some(dispatcher.open(&req).await),
-                    "close" => Some(dispatcher.close(&req).await),
-                    "debug" => Some(dispatcher.debug(&req).await),
-                    _ => None,
-                };
-                if let Some(response) = response {
-                    req.response.send(response).await;
-                    continue;
-                }
-                match dispatcher.connections.get(&req.db_name[..]) {
-                    Some(tx) => tx.send(req).await,
-                    None => {
-                        req.response
-                            .send(Err(format!("\"{}\" not open", req.db_name)))
-                            .await;
-                        continue;
-                    }
-                };
+        let req = match rx.recv().await {
+            Ok(req) => req,
+            Err(why) => {
+                warn!("Dispatch loop recv failed: {}", why);
+                continue;
             }
+        };
+
+        let response = match req.rpc.as_str() {
+            "open" => Some(do_open(&mut conns, &req).await),
+            "close" => Some(do_close(&mut conns, &req).await),
+            "debug" => Some(do_debug(&conns, &req).await),
+            _ => None,
+        };
+        if let Some(response) = response {
+            req.response.send(response).await;
+            continue;
         }
-    }
-}
-
-async fn connection_loop(store: dag::Store, rx: Receiver<Request>) {
-    let mut h = HashMap::new();
-
-    loop {
-        match rx.recv().await {
-            Err(why) => warn!("Dispatch loop recv failed: {}", why),
-            Ok(req) => match req.rpc.as_str() {
-                "has" => {
-                    execute(Dispatcher::has, &mut h, req).await;
-                }
-                "get" => {
-                    execute(Dispatcher::get, &mut h, req).await;
-                }
-                "put" => {
-                    execute(Dispatcher::put, &mut h, req).await;
-                }
-                "openTransaction" => {
-                    use OpenTransactionError::*;
-                    let dag_write = store.write().await.map_err(DagWriteError).unwrap();
-                    let write = db::Write::new_from_head("main", dag_write)
-                        .await
-                        .map_err(DBWriteError)
-                        .unwrap();
-                    let transaction_id = TRANSACTION_COUNTER.fetch_add(1, Ordering::SeqCst);
-                    h.insert(transaction_id, write);
-                    req.response
-                        .send(Ok(SerJson::serialize_json(&OpenTransactionResponse {
-                            transaction_id: transaction_id,
-                        })))
-                        .await;
-                }
-                "close" => {
-                    req.response.send(Ok("Closed!".into())).await;
-                    break;
-                }
-                _ => {
-                    req.response.send(Err("Unsupported rpc name".into())).await;
-                }
-            },
-        }
-    }
-}
-
-async fn execute<T, E, F>(func: F, txns: &mut HashMap<u32, db::Write<'_>>, req: Request)
-where
-    T: DeJson + TransactionRequest,
-    E: std::fmt::Debug,
-    F: for<'r, 's> AsyncFn2<&'r mut db::Write<'s>, T, Output = Result<String, E>>,
-{
-    let request: T = match DeJson::deserialize_json(&req.data) {
-        Ok(v) => v,
-        Err(e) => {
-            req.response.send(Err(format!("InvalidJson({})", e))).await;
-            return;
-        }
-    };
-
-    let txn_id = request.transaction_id();
-    let mut txn = match txns.get_mut(&txn_id) {
-        Some(v) => v,
-        None => {
-            req.response
-                .send(Err(format!("No such transaction {}", txn_id)))
-                .await;
-            return;
-        }
-    };
-
-    let response = func
-        .call(&mut txn, request)
-        .await
-        .map_err(|e| format!("{:?}", e));
-    req.response.send(response).await;
-}
-
-trait TransactionRequest {
-    fn transaction_id(&self) -> u32;
-}
-
-#[derive(SerJson)]
-struct OpenTransactionResponse {
-    #[nserde(rename = "transactionId")]
-    transaction_id: u32,
-}
-
-#[derive(DeJson)]
-struct GetRequest {
-    #[nserde(rename = "transactionId")]
-    transaction_id: u32,
-    key: String,
-}
-
-impl TransactionRequest for GetRequest {
-    fn transaction_id(&self) -> u32 {
-        return self.transaction_id;
-    }
-}
-
-#[derive(SerJson)]
-struct GetResponse {
-    value: Option<String>,
-    has: bool, // Second to avoid trailing comma if value == None.
-}
-
-#[derive(DeJson)]
-struct PutRequest {
-    #[nserde(rename = "transactionId")]
-    transaction_id: u32,
-    key: String,
-    value: String,
-}
-
-impl TransactionRequest for PutRequest {
-    fn transaction_id(&self) -> u32 {
-        return self.transaction_id;
-    }
-}
-
-struct Dispatcher {
-    connections: HashMap<String, Sender<Request>>,
-}
-
-impl Dispatcher {
-    async fn open(&mut self, req: &Request) -> Response {
-        if req.db_name.is_empty() {
-            return Err("db_name must be non-empty".into());
-        }
-        if self.connections.contains_key(&req.db_name[..]) {
-            return Ok("".into());
-        }
-        match IdbStore::new(&req.db_name[..]).await {
-            Err(e) => {
-                return Err(format!("Failed to open \"{}\": {}", req.db_name, e));
-            }
-            Ok(v) => {
-                if let Some(kv) = v {
-                    let (tx, rx) = channel::<Request>(1);
-                    spawn_local(connection_loop(dag::Store::new(Box::new(kv)), rx));
-                    self.connections.insert(req.db_name.clone(), tx);
-                }
-            }
-        }
-        Ok("".into())
-    }
-
-    async fn close(&mut self, req: &Request) -> Response {
-        match self.connections.get(&req.db_name[..]) {
-            Some(tx) => {
-                let (tx2, rx2) = channel::<Response>(1);
-                tx.send(Request {
-                    db_name: req.db_name.clone(),
-                    rpc: "close".into(),
-                    data: "".into(),
-                    response: tx2,
-                })
-                .await;
-                match rx2.recv().await {
-                    Err(_e) => {
-                        // NOCOMMIT
-                        log::error!("Error response from close");
-                    }
-                    Ok(_v) => {
-                        // NOCOMMIT
-                        log::error!("Got response from close");
-                    }
-                };
-            }
+        match conns.get(&req.db_name[..]) {
+            Some(tx) => tx.send(req).await,
             None => {
-                return Ok("".into());
+                req.response
+                    .send(Err(format!("\"{}\" not open", req.db_name)))
+                    .await;
             }
-        }
-        self.connections.remove(&req.db_name);
-        Ok("".into())
-    }
-
-    async fn has(txn: &mut db::Write<'_>, req: GetRequest) -> Result<String, HasError> {
-        Ok(SerJson::serialize_json(&GetResponse {
-            has: txn.has(req.key.as_bytes()),
-            value: None,
-        }))
-    }
-
-    async fn get(txn: &mut db::Write<'_>, req: GetRequest) -> Result<String, GetError> {
-        use GetError::*;
-
-        #[cfg(not(default))] // Not enabled in production.
-        if req.key.starts_with("sleep") {
-            use async_std::task::sleep;
-            use core::time::Duration;
-
-            match req.key[5..].parse::<u64>() {
-                Ok(ms) => sleep(Duration::from_millis(ms)).await,
-                Err(_) => log::error!("No sleep"),
-            }
-        }
-
-        let got = txn.get(req.key.as_bytes());
-        let got = got.map(|buf| String::from_utf8(buf.to_vec()));
-        if let Some(Err(e)) = got {
-            return Err(InvalidUtf8(e));
-        }
-        let got = got.map(|r| r.unwrap());
-        Ok(SerJson::serialize_json(&GetResponse {
-            has: got.is_some(),
-            value: got,
-        }))
-    }
-
-    async fn put(txn: &mut db::Write<'_>, req: PutRequest) -> Result<String, PutError> {
-        txn.put(req.key.as_bytes().to_vec(), req.value.into_bytes());
-        /*
-        txn.commit(
-            "main",
-            "local-create-date",
-            "checksum",
-            42,
-            "foo",
-            b"bar",
-            None,
-        )
-        .await
-        .map_err(CommitError)?;*/
-        Ok("{}".into())
-    }
-
-    async fn debug(&self, req: &Request) -> Response {
-        match req.data.as_str() {
-            "open_dbs" => Ok(format!("{:?}", self.connections.keys())),
-            _ => Err("Debug command not defined".into()),
-        }
+        };
     }
 }
 
@@ -314,25 +77,47 @@ pub async fn dispatch(db_name: String, rpc: String, data: String) -> Response {
     }
 }
 
-#[derive(Debug)]
-enum OpenTransactionError {
-    DagWriteError(dag::Error),
-    DBWriteError(db::NewError),
+async fn do_open(conns: &mut ConnMap, req: &Request) -> Response {
+    if req.db_name.is_empty() {
+        return Err("db_name must be non-empty".into());
+    }
+    if conns.contains_key(&req.db_name[..]) {
+        return Ok("".into());
+    }
+    match IdbStore::new(&req.db_name[..]).await {
+        Err(e) => Err(format!("Failed to open \"{}\": {}", req.db_name, e)),
+        Ok(v) => {
+            if let Some(kv) = v {
+                let (tx, rx) = channel::<Request>(1);
+                spawn_local(connection::process(dag::Store::new(Box::new(kv)), rx));
+                conns.insert(req.db_name.clone(), tx);
+            }
+            Ok("".into())
+        }
+    }
 }
 
-#[derive(Debug)]
-enum HasError {}
-
-#[derive(Debug)]
-enum GetError {
-    InvalidUtf8(std::string::FromUtf8Error),
+async fn do_close(conns: &mut ConnMap, req: &Request) -> Response {
+    let tx = match conns.get(&req.db_name[..]) {
+        None => return Ok("".into()),
+        Some(v) => v,
+    };
+    let (tx2, rx2) = channel::<Response>(1);
+    tx.send(Request {
+        db_name: req.db_name.clone(),
+        rpc: "close".into(),
+        data: "".into(),
+        response: tx2,
+    })
+    .await;
+    let _ = rx2.recv().await;
+    conns.remove(&req.db_name);
+    Ok("".into())
 }
 
-#[derive(Debug)]
-enum PutError {}
-
-#[allow(dead_code)]
-#[derive(Debug)]
-enum CommitError {
-    CommitError(db::CommitError),
+async fn do_debug(conns: &ConnMap, req: &Request) -> Response {
+    match req.data.as_str() {
+        "open_dbs" => Ok(format!("{:?}", conns.keys())),
+        _ => Err("Debug command not defined".into()),
+    }
 }

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -8,6 +8,8 @@
 //! request/response message passing of byte arrays in and out so that
 //! it can work with a variety of hosts.
 
+mod connection;
 mod dispatch;
+pub mod types;
 
 pub use dispatch::dispatch;

--- a/src/embed/types.rs
+++ b/src/embed/types.rs
@@ -1,0 +1,39 @@
+#![allow(clippy::redundant_pattern_matching)] // For derive(DeJson).
+
+use nanoserde::{DeJson, SerJson};
+
+#[derive(DeJson, SerJson)]
+pub struct OpenTransactionResponse {
+    #[nserde(rename = "transactionId")]
+    pub transaction_id: u32,
+}
+
+#[derive(DeJson)]
+pub struct CommitTransactionRequest {
+    #[nserde(rename = "transactionId")]
+    pub transaction_id: u32,
+}
+
+#[derive(SerJson)]
+pub struct CommitTransactionResponse {}
+
+#[derive(DeJson)]
+pub struct GetRequest {
+    #[nserde(rename = "transactionId")]
+    pub transaction_id: u32,
+    pub key: String,
+}
+
+#[derive(DeJson, SerJson)]
+pub struct GetResponse {
+    pub value: Option<String>,
+    pub has: bool, // Second to avoid trailing comma if value == None.
+}
+
+#[derive(DeJson)]
+pub struct PutRequest {
+    #[nserde(rename = "transactionId")]
+    pub transaction_id: u32,
+    pub key: String,
+    pub value: String,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate log;
 
 mod dag;
 mod db;
-mod embed;
+pub mod embed;
 mod hash;
 
 #[cfg(not(default))]

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,19 +1,25 @@
+#![recursion_limit = "256"]
+
 use futures::join;
 use nanoserde::DeJson;
+use rand::Rng;
+use replicache_client::embed::types::*;
 use replicache_client::wasm;
 use wasm_bindgen_test::wasm_bindgen_test_configure;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-#[derive(DeJson)]
-struct OpenTransactionResponse {
-    #[nserde(rename = "transactionId")]
-    transaction_id: u32,
+fn random_db() -> String {
+    let mut rng = rand::thread_rng();
+    std::iter::repeat(())
+        .map(|_| rng.sample(rand::distributions::Alphanumeric))
+        .take(12)
+        .collect()
 }
 
 #[wasm_bindgen_test]
-async fn test_dag() {
+async fn dag() {
     wasm::exercise_prolly().await;
 }
 
@@ -24,8 +30,77 @@ async fn dispatch(db: &str, rpc: &str, data: &str) -> Result<String, String> {
     }
 }
 
+async fn open_transaction(db_name: &str) -> u32 {
+    let resp: OpenTransactionResponse =
+        DeJson::deserialize_json(&dispatch(db_name, "openTransaction", "").await.unwrap()).unwrap();
+    resp.transaction_id
+}
+
+async fn put(db_name: &str, txn_id: u32, key: &str, value: &str) {
+    assert_eq!(
+        dispatch(
+            db_name,
+            "put",
+            &format!(
+                "{{\"transactionId\": {}, \"key\": \"{}\", \"value\": \"{}\"}}",
+                txn_id, key, value
+            )
+        )
+        .await
+        .unwrap(),
+        "{}"
+    );
+}
+
+async fn has(db_name: &str, txn_id: u32, key: &str) -> bool {
+    let result = dispatch(
+        db_name,
+        "get",
+        &format!("{{\"transactionId\": {}, \"key\": \"{}\"}}", txn_id, key),
+    )
+    .await
+    .unwrap();
+    let response: GetResponse = DeJson::deserialize_json(&result).unwrap();
+    response.has
+}
+
+async fn get(db_name: &str, txn_id: u32, key: &str) -> Option<String> {
+    let result = dispatch(
+        db_name,
+        "get",
+        &format!("{{\"transactionId\": {}, \"key\": \"{}\"}}", txn_id, key),
+    )
+    .await
+    .unwrap();
+    let response: GetResponse = DeJson::deserialize_json(&result).unwrap();
+    match response.has {
+        true => Some(response.value.unwrap()),
+        false => None,
+    }
+}
+
+async fn commit(db_name: &str, txn_id: u32) -> Result<(), String> {
+    dispatch(
+        db_name,
+        "commitTransaction",
+        &format!("{{\"transactionId\": {}}}", txn_id),
+    )
+    .await
+    .map(|_| ())
+}
+
+async fn abort(db_name: &str, txn_id: u32) {
+    dispatch(
+        db_name,
+        "closeTransaction",
+        &format!("{{\"transactionId\": {}}}", txn_id),
+    )
+    .await
+    .unwrap();
+}
+
 #[wasm_bindgen_test]
-async fn test_dispatch() {
+async fn open_close() {
     assert_eq!(dispatch("", "debug", "open_dbs").await.unwrap(), "[]");
     assert_eq!(
         dispatch("", "open", "").await.unwrap_err(),
@@ -49,62 +124,104 @@ async fn test_dispatch() {
 }
 
 #[wasm_bindgen_test]
-async fn test_dispatch_concurrency() {
+async fn dispatch_concurrency() {
+    let db = &random_db();
     let window = web_sys::window().expect("should have a window in this context");
     let performance = window
         .performance()
         .expect("performance should be available");
 
-    assert_eq!(dispatch("db", "open", "").await.unwrap(), "");
+    assert_eq!(dispatch(db, "open", "").await.unwrap(), "");
+    let txn_id = open_transaction(db).await;
     let now_ms = performance.now();
     join!(
         async {
-            dispatch("db", "get", "{\"key\": \"sleep100\"}")
-                .await
-                .unwrap();
+            get(db, txn_id, "sleep100").await;
         },
         async {
-            dispatch("db", "get", "{\"key\": \"sleep100\"}")
-                .await
-                .unwrap();
+            get(db, txn_id, "sleep100").await;
         }
     );
     let elapsed_ms = performance.now() - now_ms;
-    assert_eq!(dispatch("db", "close", "").await.unwrap(), "");
+    abort(db, txn_id).await;
+    assert_eq!(dispatch(db, "close", "").await.unwrap(), "");
     assert_eq!(elapsed_ms >= 100., true);
     assert_eq!(elapsed_ms < 200., true);
 }
 
 #[wasm_bindgen_test]
-async fn test_get_put() {
-    assert_eq!(
-        dispatch("db", "put", "{\"k\", \"v\"}").await.unwrap_err(),
-        "\"db\" not open"
+async fn write_concurrency() {
+    let db = &random_db();
+
+    dispatch(db, "open", "").await.unwrap();
+    let txn_id = open_transaction(db).await;
+    put(db, txn_id, "value", "1").await;
+    commit(db, txn_id).await.unwrap();
+
+    // TODO(nate): Strengthen test to prove these open waits overlap.
+    join!(
+        async {
+            let txn_id = open_transaction(db).await;
+            let value = get(db, txn_id, "value")
+                .await
+                .unwrap()
+                .parse::<u32>()
+                .unwrap();
+            put(db, txn_id, "value", &(value + 2).to_string()).await;
+            commit(db, txn_id).await.unwrap();
+        },
+        async {
+            let txn_id = open_transaction(db).await;
+            let value = get(db, txn_id, "value")
+                .await
+                .unwrap()
+                .parse::<u32>()
+                .unwrap();
+            put(db, txn_id, "value", &(value + 3).to_string()).await;
+            commit(db, txn_id).await.unwrap();
+        }
     );
-    assert_eq!(dispatch("db", "open", "").await.unwrap(), "");
+    let txn_id = open_transaction(db).await;
+    assert_eq!(
+        get(db, txn_id, "value")
+            .await
+            .unwrap()
+            .parse::<u32>()
+            .unwrap(),
+        6
+    );
+    abort(db, txn_id).await;
+
+    assert_eq!(dispatch(db, "close", "").await.unwrap(), "");
+}
+
+#[wasm_bindgen_test]
+async fn get_put() {
+    let db = &random_db();
+
+    assert_eq!(
+        dispatch(db, "put", "{\"k\", \"v\"}").await.unwrap_err(),
+        format!("\"{}\" not open", db)
+    );
+    assert_eq!(dispatch(db, "open", "").await.unwrap(), "");
 
     // Check request parsing, both missing and unexpected fields.
     assert_eq!(
-        dispatch("db", "put", "{}").await.unwrap_err(),
+        dispatch(db, "put", "{}").await.unwrap_err(),
         "InvalidJson(Json Deserialize error: Key not found transaction_id, line:1 col:3)"
     );
 
-    let transaction_resp: OpenTransactionResponse =
-        match DeJson::deserialize_json(&dispatch("db", "openTransaction", "").await.unwrap()) {
-            Ok(v) => v,
-            Err(e) => panic!("Failed to parse openTransactionResponse: {}", e),
-        };
-    let transaction_id = transaction_resp.transaction_id;
+    let txn_id = open_transaction(db).await;
 
     // With serde we can use #[serde(deny_unknown_fields)] to parse strictly,
     // but that's not available with nanoserde.
     assert_eq!(
         dispatch(
-            "db",
+            db,
             "get",
             &format!(
                 "{{\"transactionId\": {}, \"key\": \"Hello\", \"value\": \"世界\"}}",
-                transaction_id
+                txn_id,
             )
         )
         .await
@@ -114,82 +231,25 @@ async fn test_get_put() {
 
     // Simple put then get test.
     // TODO(nate): Resolve how to pass non-UTF-8 sequences through the API.
-    assert_eq!(
-        dispatch(
-            "db",
-            "put",
-            &format!(
-                "{{\"transactionId\": {}, \"key\": \"Hello\", \"value\": \"世界\"}}",
-                transaction_id
-            )
-        )
-        .await
-        .unwrap(),
-        "{}"
-    );
-    assert_eq!(
-        dispatch(
-            "db",
-            "get",
-            &format!(
-                "{{\"transactionId\": {}, \"key\": \"Hello\"}}",
-                transaction_id
-            )
-        )
-        .await
-        .unwrap(),
-        "{\"value\":\"世界\",\"has\":true}"
-    );
-
-    // NOCOMMIT: Commit.
+    put(db, txn_id, "Hello", "世界").await;
+    assert_eq!(get(db, txn_id, "Hello").await.unwrap(), "世界");
+    commit(db, txn_id).await.unwrap();
 
     // Open new transaction, and verify write is persistent.
-    let transaction_resp: OpenTransactionResponse =
-        match DeJson::deserialize_json(&dispatch("db", "openTransaction", "").await.unwrap()) {
-            Ok(v) => v,
-            Err(e) => panic!("Failed to parse openTransactionResponse: {}", e),
-        };
-    let transaction_id = transaction_resp.transaction_id;
-    assert_eq!(
-        dispatch(
-            "db",
-            "get",
-            &format!(
-                "{{\"transactionId\": {}, \"key\": \"Hello\"}}",
-                transaction_id
-            )
-        )
-        .await
-        .unwrap(),
-        "{\"value\":\"世界\",\"has\":true}"
-    );
-
-    /*
+    let txn_id = open_transaction(db).await;
+    assert_eq!(get(db, txn_id, "Hello").await.unwrap(), "世界");
 
     // Verify functioning of non-ASCII keys.
-    assert_eq!(
-        dispatch("db", "has", "{\"key\": \"你好\"}").await.unwrap(),
-        "{\"has\":false}"
-    );
-    assert_eq!(
-        dispatch("db", "get", "{\"key\": \"你好\"}").await.unwrap(),
-        "{\"has\":false}"
-    );
-    assert_eq!(
-        dispatch("db", "put", "{\"key\": \"你好\", \"value\": \"world\"}")
-            .await
-            .unwrap(),
-        "{}"
-    );
-    assert_eq!(
-        dispatch("db", "has", "{\"key\": \"你好\"}").await.unwrap(),
-        "{\"has\":true}"
-    );
-    assert_eq!(
-        dispatch("db", "get", "{\"key\": \"你好\"}").await.unwrap(),
-        "{\"value\":\"world\",\"has\":true}"
-    );
+    assert_eq!(has(db, txn_id, "你好").await, false);
+    assert_eq!(get(db, txn_id, "你好").await, None);
+    put(db, txn_id, "你好", "world").await;
+    assert_eq!(has(db, txn_id, "你好").await, true);
+    assert_eq!(get(db, txn_id, "你好").await, Some("world".into()));
 
-    assert_eq!(dispatch("db", "close", "").await.unwrap(), "");
-    */
+    commit(db, txn_id).await.unwrap();
+    let txn_id = open_transaction(db).await;
+    assert_eq!(has(db, txn_id, "你好").await, true);
+    assert_eq!(get(db, txn_id, "你好").await, Some("world".into()));
+
+    assert_eq!(dispatch(db, "close", "").await.unwrap(), "");
 }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,9 +1,16 @@
 use futures::join;
+use nanoserde::DeJson;
 use replicache_client::wasm;
 use wasm_bindgen_test::wasm_bindgen_test_configure;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
+
+#[derive(DeJson)]
+struct OpenTransactionResponse {
+    #[nserde(rename = "transactionId")]
+    transaction_id: u32,
+}
 
 #[wasm_bindgen_test]
 async fn test_dag() {
@@ -79,29 +86,85 @@ async fn test_get_put() {
     // Check request parsing, both missing and unexpected fields.
     assert_eq!(
         dispatch("db", "put", "{}").await.unwrap_err(),
-        "InvalidJson(Json Deserialize error: Key not found key, line:1 col:3)"
+        "InvalidJson(Json Deserialize error: Key not found transaction_id, line:1 col:3)"
     );
+
+    let transaction_resp: OpenTransactionResponse =
+        match DeJson::deserialize_json(&dispatch("db", "openTransaction", "").await.unwrap()) {
+            Ok(v) => v,
+            Err(e) => panic!("Failed to parse openTransactionResponse: {}", e),
+        };
+    let transaction_id = transaction_resp.transaction_id;
+
     // With serde we can use #[serde(deny_unknown_fields)] to parse strictly,
     // but that's not available with nanoserde.
     assert_eq!(
-        dispatch("db", "get", "{\"key\": \"Hello\", \"value\": \"世界\"}")
-            .await
-            .unwrap(),
+        dispatch(
+            "db",
+            "get",
+            &format!(
+                "{{\"transactionId\": {}, \"key\": \"Hello\", \"value\": \"世界\"}}",
+                transaction_id
+            )
+        )
+        .await
+        .unwrap(),
         "{\"has\":false}", // unwrap_err() == "Failed to parse request"
     );
 
     // Simple put then get test.
     // TODO(nate): Resolve how to pass non-UTF-8 sequences through the API.
     assert_eq!(
-        dispatch("db", "put", "{\"key\": \"Hello\", \"value\": \"世界\"}")
-            .await
-            .unwrap(),
+        dispatch(
+            "db",
+            "put",
+            &format!(
+                "{{\"transactionId\": {}, \"key\": \"Hello\", \"value\": \"世界\"}}",
+                transaction_id
+            )
+        )
+        .await
+        .unwrap(),
         "{}"
     );
     assert_eq!(
-        dispatch("db", "get", "{\"key\": \"Hello\"}").await.unwrap(),
+        dispatch(
+            "db",
+            "get",
+            &format!(
+                "{{\"transactionId\": {}, \"key\": \"Hello\"}}",
+                transaction_id
+            )
+        )
+        .await
+        .unwrap(),
         "{\"value\":\"世界\",\"has\":true}"
     );
+
+    // NOCOMMIT: Commit.
+
+    // Open new transaction, and verify write is persistent.
+    let transaction_resp: OpenTransactionResponse =
+        match DeJson::deserialize_json(&dispatch("db", "openTransaction", "").await.unwrap()) {
+            Ok(v) => v,
+            Err(e) => panic!("Failed to parse openTransactionResponse: {}", e),
+        };
+    let transaction_id = transaction_resp.transaction_id;
+    assert_eq!(
+        dispatch(
+            "db",
+            "get",
+            &format!(
+                "{{\"transactionId\": {}, \"key\": \"Hello\"}}",
+                transaction_id
+            )
+        )
+        .await
+        .unwrap(),
+        "{\"value\":\"世界\",\"has\":true}"
+    );
+
+    /*
 
     // Verify functioning of non-ASCII keys.
     assert_eq!(
@@ -128,4 +191,5 @@ async fn test_get_put() {
     );
 
     assert_eq!(dispatch("db", "close", "").await.unwrap(), "");
+    */
 }


### PR DESCRIPTION
Creates a new spawned future for each database connection, and causes dispatch_loop()
to forward messages for that database to that future. There, the db::Store and a map of transactions
are owned on the stack, and a FuturesUnordered is used to enqueue a future per incoming RPC to
run in parallel while depending on the stack for ownership of the transactions.

With this, multiple reads can run in parallel on a transaction, and multiple write transactions will queue
until they can receive a write lock from the underlying Store.