### PR TITLE
Remove a bunch of #[allow(dead_code)] annotations.

### DIFF
--- a/src/dag/read.rs
+++ b/src/dag/read.rs
@@ -8,7 +8,6 @@ pub struct OwnedRead<'a> {
     kvr: Box<dyn kv::Read + 'a>,
 }
 
-#[allow(dead_code)]
 impl<'a> OwnedRead<'a> {
     pub fn new(kvr: Box<dyn kv::Read + 'a>) -> OwnedRead {
         OwnedRead { kvr }
@@ -20,17 +19,17 @@ impl<'a> OwnedRead<'a> {
         }
     }
 }
-#[allow(dead_code)]
+
 pub struct Read<'a> {
     kvr: &'a dyn kv::Read,
 }
 
-#[allow(dead_code)]
 impl<'a> Read<'_> {
     pub fn new(kvr: &'a dyn kv::Read) -> Read {
         Read { kvr }
     }
 
+    #[allow(dead_code)]
     pub async fn has_chunk(&self, hash: &str) -> Result<bool> {
         Ok(self.kvr.has(&Key::ChunkData(hash).to_string()).await?)
     }

--- a/src/dag/store.rs
+++ b/src/dag/store.rs
@@ -12,7 +12,6 @@ impl Store {
         Store { kv }
     }
 
-    #[allow(dead_code)]
     pub async fn read(&self) -> Result<OwnedRead<'_>> {
         Ok(OwnedRead::new(self.kv.read().await?))
     }

--- a/src/db/read.rs
+++ b/src/db/read.rs
@@ -2,7 +2,6 @@ use super::commit::{Commit, FromHeadError};
 use crate::dag;
 use crate::prolly;
 
-#[allow(dead_code)]
 pub struct OwnedRead<'a> {
     dag_read: dag::OwnedRead<'a>,
     map: prolly::Map,
@@ -14,7 +13,6 @@ pub enum NewReadFromHeadError {
     MapLoadError(prolly::LoadError),
 }
 
-#[allow(dead_code)]
 impl<'a> OwnedRead<'a> {
     pub async fn new_from_head(
         head_name: &str,
@@ -38,13 +36,13 @@ impl<'a> OwnedRead<'a> {
     }
 }
 
-#[allow(dead_code)]
 pub struct Read<'a> {
+    #[allow(dead_code)]
     dag_read: dag::Read<'a>,
+
     map: &'a prolly::Map,
 }
 
-#[allow(dead_code)]
 impl<'a> Read<'a> {
     pub fn new(dag_read: dag::Read<'a>, map: &'a prolly::Map) -> Read<'a> {
         Read { dag_read, map }
@@ -58,6 +56,7 @@ impl<'a> Read<'a> {
         self.map.get(key)
     }
 
+    #[allow(dead_code)]
     pub fn scan(&'a self, opts: super::ScanOptions<'a>) -> impl Iterator<Item = prolly::Entry<'a>> {
         super::scan::scan(&self.map, opts)
     }

--- a/src/db/scan.rs
+++ b/src/db/scan.rs
@@ -1,19 +1,16 @@
 use crate::prolly;
 
-#[allow(dead_code)]
 pub struct ScanKey<'a> {
     value: &'a [u8],
     exclusive: bool,
 }
 
-#[allow(dead_code)]
 pub struct ScanBound<'a> {
     // TODO: Make these two fields exclusive?
     key: Option<ScanKey<'a>>,
     index: Option<u64>,
 }
 
-#[allow(dead_code)]
 pub struct ScanOptions<'a> {
     // TODO: Make these two fields exclusive?
     prefix: Option<&'a [u8]>,
@@ -21,7 +18,6 @@ pub struct ScanOptions<'a> {
     limit: Option<u64>,
 }
 
-#[allow(dead_code)]
 pub fn scan<'a>(
     map: &'a prolly::Map,
     opts: ScanOptions<'a>,

--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -16,7 +16,6 @@ lazy_static! {
 }
 
 enum Transaction<'a> {
-    #[allow(dead_code)]
     Read(db::OwnedRead<'a>),
     Write(db::Write<'a>),
 }

--- a/src/kv/idbstore.rs
+++ b/src/kv/idbstore.rs
@@ -148,14 +148,13 @@ impl Store for IdbStore {
 }
 
 struct ReadTransaction<'a> {
-    #[allow(dead_code)]
-    db: RwLockReadGuard<'a, IdbDatabase>,
+    _db: RwLockReadGuard<'a, IdbDatabase>, // Not referenced, holding lock.
     tx: IdbTransaction,
 }
 
 impl ReadTransaction<'_> {
     fn new(db: RwLockReadGuard<'_, IdbDatabase>, tx: IdbTransaction) -> Result<ReadTransaction> {
-        Ok(ReadTransaction { db, tx })
+        Ok(ReadTransaction { _db: db, tx })
     }
 }
 
@@ -208,8 +207,7 @@ enum WriteState {
 }
 
 struct WriteTransaction<'a> {
-    #[allow(dead_code)]
-    db: RwLockWriteGuard<'a, IdbDatabase>,
+    _db: RwLockWriteGuard<'a, IdbDatabase>, // Not referenced, holding lock.
     tx: IdbTransaction,
     pending: Mutex<HashMap<String, Option<Vec<u8>>>>,
     pair: Arc<(Mutex<WriteState>, Condvar)>,
@@ -219,7 +217,7 @@ struct WriteTransaction<'a> {
 impl WriteTransaction<'_> {
     fn new(db: RwLockWriteGuard<'_, IdbDatabase>, tx: IdbTransaction) -> Result<WriteTransaction> {
         let mut wt = WriteTransaction {
-            db,
+            _db: db,
             tx,
             pair: Arc::new((Mutex::new(WriteState::Open), Condvar::new())),
             pending: Mutex::new(HashMap::new()),

--- a/src/prolly/leaf.rs
+++ b/src/prolly/leaf.rs
@@ -16,7 +16,6 @@ pub enum LoadError {
     Corrupt(&'static str),
 }
 
-#[allow(dead_code)]
 impl Leaf {
     pub fn chunk(&self) -> &Chunk {
         &self.chunk


### PR DESCRIPTION
In a couple places, these were moved to be more specific, e.g.:
o dag::Read::has_chunk()
o db::Read::dag_read
o db::Read::scan()

In kv::IdbStore, I exchanged these dead_code annotations for a leading
understore on the RwLock...Guard variables, as these aren't dead,
they're just unreferenced placeholders to keep a lock alive.