### PR TITLE
Browser fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
 name = "cache-padded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +213,12 @@ checksum = "a788f068dd10687940565bf4b5480ee943176cbd114b12e811074bcf7c04e4b9"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
@@ -355,6 +367,23 @@ checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "http"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
@@ -577,11 +606,14 @@ dependencies = [
  "data-encoding",
  "flatbuffers",
  "futures",
+ "http",
  "js-sys",
  "lazy_static",
  "log",
  "nanoserde",
  "rand",
+ "serde",
+ "serde_derive",
  "sha2",
  "wasm-bench",
  "wasm-bindgen",
@@ -602,6 +634,26 @@ name = "send_wrapper"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "serde"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sha2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,8 +612,6 @@ dependencies = [
  "log",
  "nanoserde",
  "rand",
- "serde",
- "serde_derive",
  "sha2",
  "wasm-bench",
  "wasm-bindgen",
@@ -634,26 +632,6 @@ name = "send_wrapper"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
-
-[[package]]
-name = "serde"
-version = "1.0.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "sha2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,9 @@ lazy_static = "1.4.0"
 log = "0.4"
 nanoserde = "0.1.18"
 sha2 = "0.8.1"
-#wasm-bindgen = { version = "0.2", features = ["serde-serialize"]  }
 wasm-bindgen = { version = "0.2"  }
 wasm-bindgen-futures = "0.4.13"
 wee_alloc = "0.4.5"
-serde = { version = "1.0.80", features = ["derive"] }
-serde_derive = "^1.0.59"
 
 
 [dev-dependencies]
@@ -36,14 +33,13 @@ async-std = { version = "=1.6.0", features = ["attributes", "unstable"] }
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }
 wasm-bench = { path = "crates/bench" }
 wasm-bindgen-test = "0.3.0"
-serde = { version = "1.0.80", features = ["derive"] }
-serde_derive = "^1.0.59"
 
 [dependencies.web-sys]
 version = "0.3.40"
 features = [
     "console",
     "DomException",
+    "Headers",
     "IdbDatabase",
     "IdbFactory",
     "IdbObjectStore",
@@ -52,13 +48,11 @@ features = [
     "IdbTransactionMode",
     "IdbVersionChangeEvent",
     "Performance",
-    "Window",
-
-    "Headers",
     "Request",
     "RequestInit",
     "RequestMode",
     "Response",
+    "Window",
 ]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,20 +17,27 @@ console_error_panic_hook = { version = "0.1.1", optional = true }
 data-encoding = "1.1.1"
 flatbuffers = "0.6.1"
 futures = "0.3.5"
+http = "0.2.1"
 js-sys = "0.3.40"
 lazy_static = "1.4.0"
 log = "0.4"
 nanoserde = "0.1.18"
 sha2 = "0.8.1"
-wasm-bindgen = "0.2"
+#wasm-bindgen = { version = "0.2", features = ["serde-serialize"]  }
+wasm-bindgen = { version = "0.2"  }
 wasm-bindgen-futures = "0.4.13"
 wee_alloc = "0.4.5"
+serde = { version = "1.0.80", features = ["derive"] }
+serde_derive = "^1.0.59"
+
 
 [dev-dependencies]
 async-std = { version = "=1.6.0", features = ["attributes", "unstable"] }
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }
 wasm-bench = { path = "crates/bench" }
 wasm-bindgen-test = "0.3.0"
+serde = { version = "1.0.80", features = ["derive"] }
+serde_derive = "^1.0.59"
 
 [dependencies.web-sys]
 version = "0.3.40"
@@ -46,6 +53,12 @@ features = [
     "IdbVersionChangeEvent",
     "Performance",
     "Window",
+
+    "Headers",
+    "Request",
+    "RequestInit",
+    "RequestMode",
+    "Response",
 ]
 
 [lib]

--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -278,8 +278,8 @@ async fn do_put(txn: &RwLock<Transaction<'_>>, req: PutRequest) -> Result<PutRes
 // do_ers to take txns even if they don't need it so this fn also helps begin_sync
 // have a simpler signature.
 async fn do_begin_sync<'a, 'b>(
-    _store: &'a dag::Store,
-    _txns: &'b TxnMap<'a>,
+    _: &'a dag::Store,
+    _: &'b TxnMap<'a>,
     req: BeginSyncRequest,
 ) -> Result<BeginSyncResponse, sync::BeginSyncError> {
     let begin_sync_response = sync::begin_sync(&req).await?;

--- a/src/embed/http.rs
+++ b/src/embed/http.rs
@@ -26,7 +26,11 @@ pub async fn browser_fetch(
     let web_sys_req = web_sys::Request::new_with_str_and_init(&http_req.uri().to_string(), &opts)?;
     let h = web_sys_req.headers();
     for (k, v) in http_req.headers().iter() {
-        h.set(k.as_ref(), v.to_str().unwrap())?;
+        h.set(
+            k.as_ref(),
+            v.to_str()
+                .map_err(|e| FetchError::new(&format!("{:?}", e)))?,
+        )?;
     }
 
     let window = web_sys::window().ok_or_else(|| FetchError::new("could not get window"))?;
@@ -50,6 +54,7 @@ pub async fn browser_fetch(
 // FetchErrors are returned by both the rust and browser versions of fetch. Since
 // lower level errors in each case will be coming from two different places I implemented
 // FetchError as lossy of the error types underneath: it holds an error string.
+// TODO turn this into an enumerated type.
 #[derive(Debug)]
 pub struct FetchError {
     msg: String,

--- a/src/embed/http.rs
+++ b/src/embed/http.rs
@@ -38,9 +38,9 @@ pub async fn browser_fetch(
     }
     let web_sys_resp: web_sys::Response = js_web_sys_resp.dyn_into().unwrap();
     let body_js_value = JsFuture::from(web_sys_resp.text()?).await?;
-    let resp_body = body_js_value.as_string().ok_or_else(|| FetchError::new(
-        "could not get http response body as string",
-    ))?;
+    let resp_body = body_js_value
+        .as_string()
+        .ok_or_else(|| FetchError::new("could not get http response body as string"))?;
 
     let builder = http::response::Builder::new();
     let http_resp = builder.status(web_sys_resp.status()).body(resp_body)?;

--- a/src/embed/http.rs
+++ b/src/embed/http.rs
@@ -1,0 +1,92 @@
+use js_sys;
+use std::convert::TryFrom;
+use std::error::Error;
+use std::fmt;
+use std::str;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{RequestInit, RequestMode};
+
+// browser_fetch makes and HTTP request over the network via the browser's Fetch API.
+// It is intended to be used in wasm; it won't work in regular rust. The response contains
+// the status and body, it doesn't populate response headers (though it easily could).
+// Since we can't run a web server in wasm land and this fn doesn't work in rust land
+// this fn is tested manually in tests/wasm.rs.
+//
+// TODO timeout/abort
+// TODO log request/response
+pub async fn browser_fetch(
+    http_req: &http::Request<String>,
+) -> Result<http::Response<String>, FetchError> {
+    let mut opts = RequestInit::new();
+    opts.method(http_req.method().as_str());
+    opts.mode(RequestMode::Cors);
+    let js_body = JsValue::from_str(http_req.body());
+    opts.body(Some(&js_body));
+    let web_sys_req = web_sys::Request::new_with_str_and_init(&http_req.uri().to_string(), &opts)?;
+    let h = web_sys_req.headers();
+    for (k, v) in http_req.headers().iter() {
+        h.set(k.as_ref(), v.to_str().unwrap())?;
+    }
+
+    let window = web_sys::window().ok_or(FetchError::new("could not get window"))?;
+    let http_req_promise = window.fetch_with_request(&web_sys_req);
+    let http_req_future = JsFuture::from(http_req_promise);
+    let js_web_sys_resp = http_req_future.await?;
+    if !js_web_sys_resp.is_instance_of::<web_sys::Response>() {
+        return Err(FetchError::new("result from future not a Response"));
+    }
+    let web_sys_resp: web_sys::Response = js_web_sys_resp.dyn_into().unwrap();
+    let body_js_value = JsFuture::from(web_sys_resp.text()?).await?;
+    let resp_body = body_js_value.as_string().ok_or(FetchError::new(
+        "could not get http response body as string",
+    ))?;
+
+    let builder = http::response::Builder::new();
+    let http_resp = builder.status(web_sys_resp.status()).body(resp_body)?;
+    Ok(http_resp)
+}
+
+// FetchErrors are returned by both the rust and browser versions of fetch. Since
+// lower level errors in each case will be coming from two different places I implemented
+// FetchError as lossy of the error types underneath: it holds an error string.
+#[derive(Debug)]
+pub struct FetchError {
+    msg: String,
+}
+
+impl FetchError {
+    fn new(msg: &str) -> FetchError {
+        FetchError {
+            msg: msg.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for FetchError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+impl Error for FetchError {
+    fn description(&self) -> &str {
+        &self.msg
+    }
+}
+
+impl From<JsValue> for FetchError {
+    fn from(err: JsValue) -> FetchError {
+        match js_sys::Error::try_from(err) {
+            Ok(e) => FetchError::new(&format!("{:?}", e)),
+            Err(_) => FetchError::new("could not convert to js_sys::Error"),
+        }
+    }
+}
+
+impl From<http::Error> for FetchError {
+    fn from(err: http::Error) -> FetchError {
+        FetchError::new(&format!("{:?}", err))
+    }
+}

--- a/src/embed/http.rs
+++ b/src/embed/http.rs
@@ -1,4 +1,3 @@
-use js_sys;
 use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;

--- a/src/embed/http.rs
+++ b/src/embed/http.rs
@@ -29,7 +29,7 @@ pub async fn browser_fetch(
         h.set(k.as_ref(), v.to_str().unwrap())?;
     }
 
-    let window = web_sys::window().ok_or(FetchError::new("could not get window"))?;
+    let window = web_sys::window().ok_or_else(|| FetchError::new("could not get window"))?;
     let http_req_promise = window.fetch_with_request(&web_sys_req);
     let http_req_future = JsFuture::from(http_req_promise);
     let js_web_sys_resp = http_req_future.await?;
@@ -38,7 +38,7 @@ pub async fn browser_fetch(
     }
     let web_sys_resp: web_sys::Response = js_web_sys_resp.dyn_into().unwrap();
     let body_js_value = JsFuture::from(web_sys_resp.text()?).await?;
-    let resp_body = body_js_value.as_string().ok_or(FetchError::new(
+    let resp_body = body_js_value.as_string().ok_or_else(|| FetchError::new(
         "could not get http response body as string",
     ))?;
 

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -10,6 +10,8 @@
 
 mod connection;
 mod dispatch;
-pub mod types;
 
+pub mod http;
+pub mod sync;
+pub mod types;
 pub use dispatch::dispatch;

--- a/src/embed/sync.rs
+++ b/src/embed/sync.rs
@@ -71,7 +71,7 @@ pub async fn pull(begin_sync_req: &BeginSyncRequest) -> Result<PullResponse, Pul
     if USE_BROWSER_FETCH {
         let http_resp = embed_http::browser_fetch(&http_req).await?;
         if http_resp.status() != http::StatusCode::OK {
-            return Err(PullError::FetchNotOk(http_resp.status().clone()));
+            return Err(PullError::FetchNotOk(http_resp.status()));
         }
         let pull_resp: PullResponse = DeJson::deserialize_json(http_resp.body())?;
         // TODO do something with it

--- a/src/embed/sync.rs
+++ b/src/embed/sync.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::redundant_pattern_matching)] // For derive(DeJson).
+
 use super::http as embed_http;
 use super::types::*;
 use nanoserde::{DeJson, DeJsonErr, SerJson};

--- a/src/embed/sync.rs
+++ b/src/embed/sync.rs
@@ -1,0 +1,128 @@
+use super::http as embed_http;
+use super::types::*;
+use nanoserde::{DeJson, DeJsonErr, SerJson};
+use std::fmt::Debug;
+
+#[cfg(default)]
+const USE_BROWSER_FETCH: bool = false;
+
+#[cfg(not(default))]
+const USE_BROWSER_FETCH: bool = true;
+
+pub async fn begin_sync(
+    begin_sync_req: &BeginSyncRequest,
+) -> Result<BeginSyncResponse, BeginSyncError> {
+    let _pull_resp = pull(begin_sync_req).await?;
+    // TODO do something with the response
+    Ok(BeginSyncResponse {})
+}
+
+#[derive(Debug)]
+pub enum BeginSyncError {
+    PullFailed(PullError),
+}
+
+impl From<PullError> for BeginSyncError {
+    fn from(err: PullError) -> BeginSyncError {
+        BeginSyncError::PullFailed(err)
+    }
+}
+
+#[derive(Default, SerJson)]
+pub struct PullRequest {
+    #[nserde(rename = "clientViewAuth")]
+    pub client_view_auth: String,
+    #[nserde(rename = "clientID")]
+    pub client_id: String,
+    #[nserde(rename = "baseStateID")]
+    pub base_state_id: String,
+    #[nserde(rename = "checksum")]
+    pub checksum: String,
+}
+
+#[derive(Default, DeJson)]
+pub struct PullResponse {
+    #[nserde(rename = "stateID")]
+    #[allow(dead_code)]
+    state_id: String,
+    #[nserde(rename = "lastMutationID")]
+    #[allow(dead_code)]
+    last_mutation_id: String,
+    // 	TODO Patch          []kv.Operation `json:"patch"`
+    #[nserde(rename = "checksum")]
+    #[allow(dead_code)]
+    checksum: String,
+    // TODO ClientViewInfo ClientViewInfo `json:"clientViewInfo"`
+}
+
+pub async fn pull(begin_sync_req: &BeginSyncRequest) -> Result<PullResponse, PullError> {
+    let pull_req = PullRequest {
+        client_view_auth: begin_sync_req.data_layer_auth.clone(),
+        client_id: "TODO".to_string(),
+        base_state_id: "TODO".to_string(),
+        checksum: "TODO".to_string(),
+    };
+    let http_req = new_pull_http_request(
+        &pull_req,
+        &begin_sync_req.diff_server_url,
+        &begin_sync_req.diff_server_auth,
+    )?;
+
+    if USE_BROWSER_FETCH {
+        let http_resp = embed_http::browser_fetch(&http_req).await?;
+        if http_resp.status() != http::StatusCode::OK {
+            return Err(PullError::FetchNotOk(http_resp.status().clone()));
+        }
+        let pull_resp: PullResponse = DeJson::deserialize_json(http_resp.body())?;
+        // TODO do something with it
+        return Ok(pull_resp);
+    }
+
+    Err(PullError::NotYetImplemented)
+}
+
+// Pulled into a helper fn because we use it integration tests.
+pub fn new_pull_http_request(
+    pull_req: &PullRequest,
+    diff_server_url: &str,
+    diff_server_auth: &str,
+) -> Result<http::Request<String>, PullError> {
+    let body = SerJson::serialize_json(pull_req);
+    let builder = http::request::Builder::new();
+    let http_req = builder
+        .method("POST")
+        .uri(diff_server_url)
+        .header("Content-type", "application/json")
+        .header("Authorization", diff_server_auth)
+        .header("X-Replicache-SyncID", "TODO")
+        .body(body)?;
+    Ok(http_req)
+}
+
+#[derive(Debug)]
+pub enum PullError {
+    InvalidRequest(http::Error),
+    FetchFailed(embed_http::FetchError),
+    FetchNotOk(http::StatusCode),
+    InvalidResponse(DeJsonErr),
+
+    NotYetImplemented,
+}
+
+impl From<http::Error> for PullError {
+    fn from(err: http::Error) -> PullError {
+        PullError::InvalidRequest(err)
+    }
+}
+
+impl From<embed_http::FetchError> for PullError {
+    fn from(err: embed_http::FetchError) -> PullError {
+        PullError::FetchFailed(err)
+    }
+}
+
+impl From<DeJsonErr> for PullError {
+    fn from(err: DeJsonErr) -> PullError {
+        PullError::InvalidResponse(err)
+    }
+}

--- a/src/embed/types.rs
+++ b/src/embed/types.rs
@@ -67,3 +67,21 @@ pub struct PutRequest {
 
 #[derive(DeJson, SerJson)]
 pub struct PutResponse {}
+
+#[derive(DeJson, SerJson)]
+pub struct BeginSyncRequest {
+    // TODO BatchPushURL   string `json:"batchPushURL"`
+    // data_layer_auth is used for push and for pull (as the client_view_auth).
+    #[nserde(rename = "dataLayerAuth")]
+    pub data_layer_auth: String,
+    #[nserde(rename = "diffServerURL")]
+    pub diff_server_url: String,
+    #[nserde(rename = "diffServerAuth")]
+    pub diff_server_auth: String,
+}
+
+#[derive(DeJson, SerJson)]
+pub struct BeginSyncResponse {
+    // TODO SyncHead jsnoms.Hash `json:"syncHead"`
+// TODO SyncInfo db.SyncInfo `json:"syncInfo"`
+}

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -268,17 +268,18 @@ async fn get_put() {
 //     - method
 //     - http headers
 //     - outgoing and incoming body
-#[wasm_bindgen_test]
-async fn test_browser_fetch() {
-    let pull_req = sync::PullRequest {
-        ..Default::default()
-    };
-    let http_req = sync::new_pull_http_request(
-        &pull_req,
-        "https://account-service.rocicorp.now.sh/api/hello",
-        "auth",
-    )
-    .unwrap();
-    let resp = http::browser_fetch(&http_req).await.unwrap();
-    assert!(resp.body().contains("Well hello to you"));
-}
+//
+// #[wasm_bindgen_test]
+// async fn test_browser_fetch() {
+//     let pull_req = sync::PullRequest {
+//         ..Default::default()
+//     };
+//     let http_req = sync::new_pull_http_request(
+//         &pull_req,
+//         "https://account-service.rocicorp.now.sh/api/hello",
+//         "auth",
+//     )
+//     .unwrap();
+//     let resp = http::browser_fetch(&http_req).await.unwrap();
+//     assert!(resp.body().contains("Well hello to you"));
+// }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -3,7 +3,9 @@
 use futures::join;
 use nanoserde::{DeJson, SerJson};
 use rand::Rng;
+#[allow(unused_imports)]
 use replicache_client::embed::http;
+#[allow(unused_imports)]
 use replicache_client::embed::sync;
 use replicache_client::embed::types::*;
 use replicache_client::wasm;

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -3,6 +3,8 @@
 use futures::join;
 use nanoserde::{DeJson, SerJson};
 use rand::Rng;
+use replicache_client::embed::http;
+use replicache_client::embed::sync;
 use replicache_client::embed::types::*;
 use replicache_client::wasm;
 use wasm_bindgen_test::wasm_bindgen_test_configure;
@@ -254,4 +256,29 @@ async fn get_put() {
     assert_eq!(get(db, txn_id, "你好").await, Some("world".into()));
 
     assert_eq!(dispatch(db, "close", "").await.unwrap(), "");
+}
+
+// We can't run a web server in wasm-in-the-browser so this is the next
+// best thing: a manual test that FETCHES OVER THE NETWORK. To run it:
+// 1. uncomment it out
+// 2. wasm-pack test --chrome -- --test wasm
+// 3. open developer tools in a browser window
+// 4. navigate to 127.0.0.1:8000
+// 5. verify the request and response by inspection:
+//     - method
+//     - http headers
+//     - outgoing and incoming body
+#[wasm_bindgen_test]
+async fn test_browser_fetch() {
+    let pull_req = sync::PullRequest {
+        ..Default::default()
+    };
+    let http_req = sync::new_pull_http_request(
+        &pull_req,
+        "https://account-service.rocicorp.now.sh/api/hello",
+        "auth",
+    )
+    .unwrap();
+    let resp = http::browser_fetch(&http_req).await.unwrap();
+    assert!(resp.body().contains("Well hello to you"));
 }


### PR DESCRIPTION
implement browser fetch and the skeleton of beginsync. all it does is attempt to pull.

there is no test for the begin sync or pull code yet. that comes next when i implement http::rust_fetch which means we can write unit tests for pull and sync against an http server.

progress towards #43 