### PR TITLE
Various changes to db::Commit API

### DIFF
--- a/src/db/commit.rs
+++ b/src/db/commit.rs
@@ -72,13 +72,13 @@ impl Commit {
         Ok(Commit { chunk })
     }
 
-    pub async fn from_hash(hash: &str, dag_read: dag::Read<'_>) -> Result<Commit, FromHashError> {
+    pub async fn from_hash(hash: &str, dag_read: &dag::Read<'_>) -> Result<Commit, FromHashError> {
         use FromHashError::*;
         let chunk = dag_read
             .get_chunk(&hash)
             .await
             .map_err(GetChunkFailed)?
-            .ok_or(ChunkMissing(hash.to_string()))?;
+            .ok_or_else(|| ChunkMissing(hash.to_string()))?;
         let commit = Commit::from_chunk(chunk).map_err(LoadCommitFailed)?;
         Ok(commit)
     }

--- a/src/db/commit.rs
+++ b/src/db/commit.rs
@@ -72,10 +72,7 @@ impl Commit {
         Ok(Commit { chunk })
     }
 
-    pub async fn from_hash(
-        hash: &str,
-        dag_read: dag::Read<'_>,
-    ) -> Result<Option<Commit>, FromHashError> {
+    pub async fn from_hash(hash: &str, dag_read: dag::Read<'_>) -> Result<Commit, FromHashError> {
         use FromHashError::*;
         let chunk = dag_read
             .get_chunk(&hash)
@@ -83,7 +80,7 @@ impl Commit {
             .map_err(GetChunkFailed)?
             .ok_or(ChunkMissing(hash.to_string()))?;
         let commit = Commit::from_chunk(chunk).map_err(LoadCommitFailed)?;
-        Ok(Some(commit))
+        Ok(commit)
     }
 
     pub fn chunk(&self) -> &dag::Chunk {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -6,4 +6,4 @@ mod write;
 
 pub use read::{read_commit, OwnedRead, Read, ReadCommitError, Whence};
 pub use scan::{ScanBound, ScanKey, ScanOptions};
-pub use write::{CommitError, Write};
+pub use write::{init_db, CommitError, InitDBError, Write};

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -6,4 +6,4 @@ mod write;
 
 pub use read::{NewReadFromHeadError, OwnedRead, Read};
 pub use scan::{ScanBound, ScanKey, ScanOptions};
-pub use write::{CommitError, NewWriteFromHeadError, Write};
+pub use write::{CommitError, NewLocalError, Write};

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,6 +4,6 @@ mod read;
 mod scan;
 mod write;
 
-pub use read::{NewReadFromHeadError, OwnedRead, Read};
+pub use read::{read_commit, OwnedRead, Read, ReadCommitError, Whence};
 pub use scan::{ScanBound, ScanKey, ScanOptions};
-pub use write::{CommitError, NewLocalError, Write};
+pub use write::{CommitError, Write};

--- a/src/db/read.rs
+++ b/src/db/read.rs
@@ -85,7 +85,7 @@ mod tests {
         let kv = MemStore::new();
         let kvw = kv.write().await.unwrap();
         let dw = dag::Write::new(kvw);
-        let mut w = write::Write::new_from_head(
+        let mut w = write::Write::new_local(
             str!("main"),
             str!("mutator_name"),
             Any::Array(vec![]),

--- a/src/db/write.rs
+++ b/src/db/write.rs
@@ -16,14 +16,14 @@ pub struct Write<'a> {
 
 #[allow(dead_code)]
 impl<'a> Write<'a> {
-    pub async fn new_from_head(
+    pub async fn new_local(
         head_name: String,
         mutator_name: String,
         mutator_args: Any,
         original_hash: Option<String>,
         dag_write: dag::Write<'a>,
-    ) -> Result<Write<'a>, NewWriteFromHeadError> {
-        use NewWriteFromHeadError::*;
+    ) -> Result<Write<'a>, NewLocalError> {
+        use NewLocalError::*;
         let basis_hash = dag_write
             .read()
             .get_head(&head_name)
@@ -117,7 +117,7 @@ impl<'a> Write<'a> {
 }
 
 #[derive(Debug)]
-pub enum NewWriteFromHeadError {
+pub enum NewLocalError {
     GetHeadError(dag::Error),
     CommitFromHashError(commit::FromHashError),
     MapLoadError(prolly::LoadError),
@@ -144,7 +144,7 @@ mod tests {
         let kv = MemStore::new();
         let kvw = kv.write().await.unwrap();
         let dw = dag::Write::new(kvw);
-        let mut w = Write::new_from_head(
+        let mut w = Write::new_local(
             str!("main"),
             str!("mutator_name"),
             Any::Array(vec![]),
@@ -160,7 +160,7 @@ mod tests {
 
         let kvw = kv.write().await.unwrap();
         let dw = dag::Write::new(kvw);
-        let w = Write::new_from_head(str!("main"), str!("mutator_name"), Any::Null, None, dw)
+        let w = Write::new_local(str!("main"), str!("mutator_name"), Any::Null, None, dw)
             .await
             .unwrap();
         let r = w.as_read();

--- a/src/db/write.rs
+++ b/src/db/write.rs
@@ -76,6 +76,25 @@ impl<'a> Write<'a> {
         })
     }
 
+    pub async fn new_snapshot(
+        whence: Whence,
+        last_mutation_id: u64,
+        server_state_id: String,
+        dag_write: dag::Write<'a>,
+    ) -> Result<Write<'a>, ReadCommitError> {
+        let (basis_hash, _, map) = read_commit(whence, &dag_write.read()).await?;
+        let basis_hash = Some(basis_hash);
+        Ok(Write {
+            basis_hash,
+            dag_write,
+            map,
+            meta: Meta::Snapshot(SnapshotMeta {
+                last_mutation_id,
+                server_state_id,
+            }),
+        })
+    }
+
     pub fn as_read(&'a self) -> super::Read<'a> {
         super::Read::new(self.dag_write.read(), &self.map)
     }

--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -182,7 +182,7 @@ async fn do_open<'a, 'b>(
             let head_name = basis.unwrap_or_else(|| DEFAULT_HEAD_NAME.to_string());
             let mutator_args = mutator_args.ok_or(ArgsRequired)?;
             let dag_write = store.write().await.map_err(DagWriteError)?;
-            let write = db::Write::new_from_head(
+            let write = db::Write::new_local(
                 head_name,
                 mutator_name,
                 mutator_args,
@@ -305,7 +305,7 @@ enum OpenTransactionError {
     ArgsRequired,
     DagWriteError(dag::Error),
     DagReadError(dag::Error),
-    DBWriteError(db::NewWriteFromHeadError),
+    DBWriteError(db::NewLocalError),
     DBReadError(db::NewReadFromHeadError),
 }
 

--- a/src/prolly/map.rs
+++ b/src/prolly/map.rs
@@ -55,7 +55,7 @@ impl Map {
         }
     }
 
-    pub async fn load(hash: &str, read: Read<'_>) -> Result<Map, LoadError> {
+    pub async fn load(hash: &str, read: &Read<'_>) -> Result<Map, LoadError> {
         let chunk = read.get_chunk(hash).await?;
         let chunk = chunk.ok_or(LoadError::UnknownHash)?;
         let base = Leaf::load(chunk)?;
@@ -439,7 +439,7 @@ mod tests {
             // The hash should yield a new map with same data
             write.commit().await.unwrap();
             let read = store.read().await.unwrap();
-            let map2 = Map::load(&hash, read.read()).await.unwrap();
+            let map2 = Map::load(&hash, &read.read()).await.unwrap();
             test(&map2, &expected);
         }
 


### PR DESCRIPTION
A series of independent commits that makes the following changes:

- Replace Commit::from_head with from_hash. There won't be a from_head convenience at this layer anymore.
- Remove db::Write::new_from_head
- Add db::Write::new_local and new_snapshot both of which can be constructed from either head name or hash
- Insert genesis commit at startup

Fixes #107, #102 , #97