### PR TITLE
Separate out debug and release resources into own directories.

### DIFF
--- a/tool/release.sh
+++ b/tool/release.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 ROOT=$DIR/../
 
 report() {
-    (cd pkg/ && ls -l replicache_client.js* replicache_client_bg.was*[mr] |
+    (cd pkg/release && ls -l replicache_client.js* replicache_client_bg.was*[mr] |
         awk '{print $9 ": " $5}')
 }
 
@@ -29,11 +29,14 @@ fi
 
     rm repc.zip
     rm -rf pkg
-    wasm-pack build --profiling -t web -- --no-default-features
-    mv pkg/replicache_client_bg.wasm pkg/replicache_client_bg_debug.wasm
-    mv pkg/replicache_client_bg.d.ts pkg/replicache_client_bg_debug.d.ts
+    wasm-pack build --debug -t web -- --no-default-features
+    brotli -f pkg/replicache_client.js pkg/replicache_client_bg.wasm
+    mv pkg debug
     wasm-pack build --release -t web -- --no-default-features
     brotli -f pkg/replicache_client.js pkg/replicache_client_bg.wasm
+    mv pkg release
+    mkdir pkg
+    mv debug release pkg/
     zip -r pkg pkg
     mv pkg.zip repc.zip
 


### PR DESCRIPTION
Also switch from profile mode to debug to get all symbols.