### PR TITLE
For discussion - do not merge - Explicitly rollback write transactions when closed.

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -16,4 +16,4 @@ pub use commit::{
 };
 pub use read::{read_commit, OwnedRead, Read, ReadCommitError, Whence};
 pub use scan::{ScanBound, ScanKey, ScanOptions};
-pub use write::{init_db, CommitError, InitDBError, Write};
+pub use write::{init_db, CommitError, InitDBError, RollbackError, Write};

--- a/src/db/write.rs
+++ b/src/db/write.rs
@@ -148,6 +148,14 @@ impl<'a> Write<'a> {
         self.checksum.to_string()
     }
 
+    pub async fn rollback(self) -> Result<(), RollbackError> {
+        Ok(self
+            .dag_write
+            .rollback()
+            .await
+            .map_err(RollbackError::DagRollbackError)?)
+    }
+
     // Return value is the hash of the new commit.
     #[allow(clippy::too_many_arguments)]
     pub async fn commit(
@@ -213,6 +221,11 @@ impl<'a> Write<'a> {
 
         Ok(commit.chunk().hash().to_string())
     }
+}
+
+#[derive(Debug)]
+pub enum RollbackError {
+    DagRollbackError(dag::Error),
 }
 
 #[derive(Debug)]

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -155,6 +155,7 @@ pub mod trait_tests {
         let rt = wt.as_read();
         assert!(rt.has("k2").await.unwrap());
         assert_eq!(Some(b"new value".to_vec()), rt.get("k2").await.unwrap());
+        wt.rollback().await.unwrap();
     }
 
     pub async fn isolation(store: &mut dyn Store) {


### PR DESCRIPTION
Failing to do this before caused a JavaScript exception because the transaction would be dropped without de-registering event handlers. When the transaction closed (implicitly) the relevant events would be fired, but the corresponding Rust closures were already gone.

An alternate (and much smaller) solution would be to de-register event handlers in a custom Drop implementation, but it seems better to have all paths go through either commit() or rollback().