### PR TITLE
time out http requests

### DIFF
--- a/src/fetch/errors.rs
+++ b/src/fetch/errors.rs
@@ -11,6 +11,7 @@ pub enum FetchError {
     InvalidResponseFromJS,
     NoWindow,
     RequestFailed(String),
+    RequestTimeout(async_std::future::TimeoutError),
     UnableToCreateRequest(String),
     UnableToSetRequestHeader(String),
 }

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -1,5 +1,8 @@
+const DEFAULT_FETCH_TIMEOUT_SECS: u64 = 10;
+
 #[cfg_attr(target_arch = "wasm32", path = "browser_client.rs")]
 #[cfg_attr(not(target_arch = "wasm32"), path = "rust_client.rs")]
 pub mod client;
 
 pub mod errors;
+mod timeout;

--- a/src/fetch/timeout.rs
+++ b/src/fetch/timeout.rs
@@ -1,0 +1,18 @@
+use crate::fetch::errors::FetchError;
+use crate::fetch::errors::FetchError::*;
+use std::future::Future;
+use std::time::Duration;
+
+pub async fn with_timeout<F>(
+    request_future: F,
+    timeout: Duration,
+) -> Result<http::Response<String>, FetchError>
+where
+    F: Future<Output = Result<http::Response<String>, FetchError>>,
+{
+    let timeout_future = async_std::future::timeout(timeout, request_future);
+    match timeout_future.await {
+        Err(e) => Err(RequestTimeout(e)),
+        Ok(r) => r,
+    }
+}

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -473,7 +473,7 @@ async fn test_rebase_opts() {
 //     - http headers
 //     - outgoing and incoming body
 //
-// #[wasm_bindgen_test]
+//#[wasm_bindgen_test]
 #[allow(dead_code)]
 async fn test_browser_fetch() {
     let pull_req = sync::PullRequest {
@@ -489,4 +489,20 @@ async fn test_browser_fetch() {
     let client = fetch::client::Client::new();
     let resp = client.request(http_req).await.unwrap();
     assert!(resp.body().contains("Well hello to you"));
+}
+
+// See note above about wasm fetch tests.
+//#[wasm_bindgen_test]
+#[allow(dead_code)]
+async fn test_browser_fetch_timeout() {
+    let req = http::request::Builder::new()
+        .method("GET")
+        .uri("https://yahoo.com/") // Safe bet it is slow as anything.
+        .body(str!(""))
+        .unwrap();
+
+    let mut client = fetch::client::Client::new();
+    client.timeout = std::time::Duration::from_millis(1);
+    let err = client.request(req).await.unwrap_err();
+    assert!(format!("{:?}", err).contains("Timeout"));
 }


### PR DESCRIPTION
i could have pulled some common client stuff up a level out of the rust/wasm-specific files but as i started on it it turned out to be more hassle and a little redundancy was easier.

closes #149 