### PR TITLE
enforce that replays are on top of sync head

### DIFF
--- a/src/db/test_helpers.rs
+++ b/src/db/test_helpers.rs
@@ -53,6 +53,9 @@ pub async fn add_local<'a>(chain: &'a mut Chain, store: &dag::Store) -> &'a mut 
     chain
 }
 
+// See also sync::test_helpers for add_sync_snapshot, which can't go here because
+// it depends on details of sync and sync depends on db.
+
 // The optional map for the commit is treated as key, value pairs.
 pub async fn add_snapshot<'a>(
     chain: &'a mut Chain,

--- a/src/embed/types.rs
+++ b/src/embed/types.rs
@@ -23,7 +23,7 @@ pub struct RebaseOpts {
     pub original_hash: String,
 }
 
-#[derive(DeJson, SerJson)]
+#[derive(Debug, DeJson, SerJson)]
 pub struct OpenTransactionResponse {
     #[nserde(rename = "transactionId")]
     pub transaction_id: u32,

--- a/src/sync/test_helpers.rs
+++ b/src/sync/test_helpers.rs
@@ -1,0 +1,82 @@
+use super::*;
+use crate::dag;
+use crate::db;
+use crate::db::test_helpers::*;
+use crate::util::nanoserde::any::Any;
+use str_macro::str;
+
+// See db::test_helpers for add_local, add_snapshot, etc. We can't put add_local_rebase
+// there because sync depends on db, and add_local_rebase depends on sync.
+
+// add_sync_snapshot adds a sync snapshot and, optionally, a local rebase commit off of the main
+// chain's base snapshot and returns them (in chain order).
+pub async fn add_sync_snapshot<'a>(
+    chain: &'a mut Chain,
+    store: &dag::Store,
+    add_replayed: bool,
+) -> Chain {
+    assert!(chain.len() >= 2); // Have to have at least a genesis and a local commit on main chain.
+
+    let mut maybe_base_snapshot: Option<&Commit> = None;
+    let mut maybe_rebased_original: Option<&Commit> = None;
+    for i in (1..chain.len()).rev() {
+        if chain[i - 1].meta().is_snapshot() {
+            maybe_base_snapshot = Some(&chain[i - 1]);
+            maybe_rebased_original = Some(&chain[i]);
+        }
+    }
+    if maybe_base_snapshot.is_none() || maybe_rebased_original.is_none() {
+        panic!("main chain doesnt have a snapshot or local commit");
+    }
+    let base_snapshot = maybe_base_snapshot.unwrap();
+    let rebased_original = maybe_rebased_original.unwrap();
+    let mut sync_chain: Chain = vec![];
+
+    // Add sync snapshot.
+    let ssid = format!("sync_server_state_id_{}", chain.len());
+    let w = db::Write::new_snapshot(
+        Whence::Hash(base_snapshot.chunk().hash().to_string()),
+        base_snapshot.mutation_id(),
+        ssid,
+        store.write().await.unwrap(),
+    )
+    .await
+    .unwrap();
+    w.commit(SYNC_HEAD_NAME, "local_create_date").await.unwrap();
+    let (sync_snapshot_hash, commit, _) = db::read_commit(
+        Whence::Head(str!(SYNC_HEAD_NAME)),
+        &store.read().await.unwrap().read(),
+    )
+    .await
+    .unwrap();
+    sync_chain.push(commit);
+    if !add_replayed {
+        return sync_chain;
+    }
+
+    // Add rebase.
+    let meta = rebased_original.meta();
+    let lm = match meta.typed() {
+        MetaTyped::Local(lm) => lm,
+        _ => panic!("not local"),
+    };
+    let w = db::Write::new_local(
+        Whence::Hash(sync_snapshot_hash),
+        str!(lm.mutator_name()),
+        Any::deserialize_json(std::str::from_utf8(lm.mutator_args_json()).unwrap()).unwrap(),
+        Some(str!(rebased_original.chunk().hash())),
+        store.write().await.unwrap(),
+    )
+    .await
+    .unwrap();
+    w.commit(SYNC_HEAD_NAME, "local_create_date").await.unwrap();
+    let (_, commit, _) = db::read_commit(
+        Whence::Head(str!(SYNC_HEAD_NAME)),
+        &store.read().await.unwrap().read(),
+    )
+    .await
+    .unwrap();
+    sync_chain.push(commit);
+
+    sync_chain
+}

--- a/src/util/nanoserde/any.rs
+++ b/src/util/nanoserde/any.rs
@@ -1,7 +1,7 @@
 use nanoserde::{DeJson, DeJsonTok, SerJson};
 use std::collections::HashMap;
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Any {
     Null,
     Bool(bool),


### PR DESCRIPTION
also add "JSLogInfo" to errors we dont want to scare customers. yes the test should probably have been table driven, it was  ported it from wasm.rs.

progress towards https://github.com/rocicorp/repc/issues/147