### PR TITLE
log dispatch rpcs

### DIFF
--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -9,7 +9,7 @@ use async_fn::AsyncFn2;
 use async_std::stream::StreamExt;
 use async_std::sync::{Receiver, RecvError, RwLock};
 use futures::stream::futures_unordered::FuturesUnordered;
-use log::warn;
+use log::{error, warn};
 use nanoserde::{DeJson, SerJson};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -84,7 +84,7 @@ async fn connection_future<'a, 'b>(
 
 pub async fn process(store: dag::Store, rx: Receiver<Request>, client_id: String) {
     if let Err(err) = do_init(&store).await {
-        warn!("Could not initialize db: {:?}", err);
+        error!("Could not initialize db: {:?}", err);
         return;
     }
 
@@ -107,6 +107,8 @@ pub async fn process(store: dag::Store, rx: Receiver<Request>, client_id: String
         }
         match value {
             UnorderedResult::Request(value) => match value {
+                // TODO turn this into an info if it is expected and not a problem or
+                // turn it into an error otherwise.
                 Err(why) => warn!("Connection loop recv failed: {}", why),
                 Ok(req) => {
                     futures.push(connection_future(

--- a/src/embed/dispatch.rs
+++ b/src/embed/dispatch.rs
@@ -4,7 +4,7 @@ use crate::kv::idbstore::IdbStore;
 use crate::kv::{Store, StoreError};
 use crate::util::uuid::uuid;
 use async_std::sync::{channel, Mutex, Receiver, Sender};
-use log::warn;
+use log::error;
 use std::collections::HashMap;
 
 #[cfg(target_arch = "wasm32")]
@@ -47,7 +47,7 @@ async fn dispatch_loop(rx: Receiver<Request>) {
         let req = match rx.recv().await {
             Ok(req) => req,
             Err(why) => {
-                warn!("Dispatch loop recv failed: {}", why);
+                error!("Dispatch loop recv failed: {}", why);
                 continue;
             }
         };

--- a/src/kv/idbstore.rs
+++ b/src/kv/idbstore.rs
@@ -4,7 +4,7 @@ use async_std::task;
 use async_trait::async_trait;
 use futures::channel::oneshot;
 use futures::future::join_all;
-use log::warn;
+use log::error;
 use std::collections::HashMap;
 use str_macro::str;
 use wasm_bindgen::closure::Closure;
@@ -98,14 +98,14 @@ impl IdbStore {
             let result = match request_copy.result() {
                 Ok(r) => r,
                 Err(e) => {
-                    warn!("Error before ugradeneeded: {:?}", e);
+                    error!("Error before ugradeneeded: {:?}", e);
                     return;
                 }
             };
             let db = web_sys::IdbDatabase::unchecked_from_js(result);
 
             if let Err(e) = db.create_object_store(OBJECT_STORE) {
-                warn!("Create object store failed: {:?}", e);
+                error!("Create object store failed: {:?}", e);
             }
         });
         request.set_onsuccess(Some(callback.as_ref().unchecked_ref()));
@@ -143,7 +143,7 @@ impl IdbStore {
         let (sender, receiver) = oneshot::channel::<()>();
         let callback = Closure::once(move || {
             if sender.send(()).is_err() {
-                warn!("oneshot send failed");
+                error!("oneshot send failed");
             }
         });
         (callback, receiver)
@@ -204,7 +204,7 @@ async fn has_impl(tx: &IdbTransaction, key: &str) -> Result<bool> {
         Some(v) if v >= 1.0 => true,
         Some(_) => false,
         _ => {
-            warn!("IdbStore.count returned non-float {:?}", result);
+            error!("IdbStore.count returned non-float {:?}", result);
             false
         }
     })

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,2 +1,3 @@
 pub mod nanoserde;
+pub mod rlog;
 pub mod uuid;

--- a/src/util/rlog/browser_timer.rs
+++ b/src/util/rlog/browser_timer.rs
@@ -1,0 +1,29 @@
+extern crate web_sys;
+use super::errors::TimerError;
+
+pub struct Timer {
+    start_ms: u64,
+}
+
+impl Timer {
+    pub fn new() -> Result<Timer, TimerError> {
+        // We could use console::time_with_label here if we wanted.
+        let start_ms = now_ms()?;
+        Ok(Timer { start_ms })
+    }
+
+    pub fn elapsed_ms(self) -> Result<u64, TimerError> {
+        let end_ms = now_ms()?;
+        Ok(end_ms - self.start_ms)
+    }
+}
+
+fn now_ms() -> Result<u64, TimerError> {
+    use TimerError::*;
+    let ms = web_sys::window()
+        .ok_or(NoWindow)?
+        .performance()
+        .ok_or(NoPerformanceTimer)?
+        .now() as u64;
+    Ok(ms)
+}

--- a/src/util/rlog/errors.rs
+++ b/src/util/rlog/errors.rs
@@ -1,0 +1,5 @@
+#[derive(Debug)]
+pub enum TimerError {
+    NoPerformanceTimer,
+    NoWindow,
+}

--- a/src/util/rlog/mod.rs
+++ b/src/util/rlog/mod.rs
@@ -1,0 +1,7 @@
+mod errors;
+#[cfg_attr(target_arch = "wasm32", path = "browser_timer.rs")]
+#[cfg_attr(not(target_arch = "wasm32"), path = "rust_timer.rs")]
+mod timer;
+
+pub use errors::TimerError;
+pub use timer::Timer;

--- a/src/util/rlog/rust_timer.rs
+++ b/src/util/rlog/rust_timer.rs
@@ -1,0 +1,31 @@
+use super::errors::TimerError;
+use std::time::Instant;
+
+pub struct Timer {
+    start: Instant,
+}
+
+impl Timer {
+    pub fn new() -> Result<Timer, TimerError> {
+        Ok(Timer {
+            start: Instant::now(),
+        })
+    }
+
+    pub fn elapsed_ms(self) -> Result<u64, TimerError> {
+        Ok(self.start.elapsed().as_millis() as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timer() {
+        let timer = Timer::new().unwrap();
+        let ten_ms = std::time::Duration::from_millis(10);
+        std::thread::sleep(ten_ms);
+        assert!(timer.elapsed_ms().unwrap() > 0);
+    }
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -32,7 +32,7 @@ static INIT: Once = Once::new();
 
 pub fn init_console_log() {
     INIT.call_once(|| {
-        if let Err(e) = console_log::init_with_level(log::Level::Info) {
+        if let Err(e) = console_log::init_with_level(log::Level::Debug) {
             web_sys::console::error_1(&format!("Error registering console_log: {}", e).into());
         }
     });

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -9,6 +9,7 @@ use replicache_client::fetch;
 #[allow(unused_imports)]
 use replicache_client::sync;
 use replicache_client::util::nanoserde::any::Any;
+use replicache_client::util::rlog;
 use replicache_client::wasm;
 use str_macro::str;
 use wasm_bindgen_test::wasm_bindgen_test_configure;
@@ -371,6 +372,13 @@ async fn test_get_root() {
         "{\"root\":\"ug6tod81n4l0fm8ob1iud4hetomibm02\"}"
     );
     assert_eq!(dispatch(db, "close", "").await.unwrap(), "");
+}
+
+#[wasm_bindgen_test]
+fn test_browser_timer() {
+    let timer = rlog::Timer::new().unwrap();
+    // Sleep is a PITA so we'll leave it at "it doesn't error".
+    timer.elapsed_ms().unwrap();
 }
 
 // We can't run a web server in wasm-in-the-browser so this is the next


### PR DESCRIPTION
- change some warns to errors
- for now, set default log level to debug 
- log full dispatch rpc request and response to console with timing
- does NOT yet properly add context or have finer grained logging eg when an rpc acquires a lock and actually starts; we just log when we receive the request and when we send the response

progress towards #49 and https://github.com/rocicorp/repc/issues/176