### PR TITLE
Close the db when onversionchange

### DIFF
--- a/src/kv/idbstore.rs
+++ b/src/kv/idbstore.rs
@@ -94,18 +94,10 @@ impl IdbStore {
         };
         let request = factory.open(name)?;
         let (callback, receiver) = IdbStore::oneshot_callback(logger.clone());
-        let request_copy = request.clone();
         let closure_logger = logger.clone();
-        let onupgradeneeded = Closure::once(move |_event: web_sys::IdbVersionChangeEvent| {
-            let result = match request_copy.result() {
-                Ok(r) => r,
-                Err(e) => {
-                    closure_logger.error(format!("Error before ugradeneeded: {:?}", e));
-                    return;
-                }
-            };
-            let db = web_sys::IdbDatabase::unchecked_from_js(result);
-
+        let onupgradeneeded = Closure::once(move |event: web_sys::IdbVersionChangeEvent| {
+            let target = event.target().unwrap();
+            let db = web_sys::IdbDatabase::unchecked_from_js_ref(target.as_ref());
             if let Err(e) = db.create_object_store(OBJECT_STORE) {
                 closure_logger.error(format!("Create object store failed: {:?}", e));
             }
@@ -114,8 +106,18 @@ impl IdbStore {
         request.set_onerror(Some(callback.as_ref().unchecked_ref()));
         request.set_onupgradeneeded(Some(onupgradeneeded.as_ref().unchecked_ref()));
         receiver.await?;
+
+        let onversionchange = Closure::once(move |event: web_sys::IdbVersionChangeEvent| {
+            let target = event.target().unwrap();
+            let db = web_sys::IdbDatabase::unchecked_from_js_ref(target.as_ref());
+            db.close();
+        });
+
+        let db: IdbDatabase = request.result()?.into();
+        db.set_onversionchange(Some(onversionchange.as_ref().unchecked_ref()));
+
         Ok(Some(IdbStore {
-            db: RwLock::new(request.result()?.into()),
+            db: RwLock::new(db),
         }))
     }
 

--- a/src/kv/idbstore.rs
+++ b/src/kv/idbstore.rs
@@ -122,6 +122,7 @@ impl IdbStore {
             db_copy.close();
         });
         db.set_onversionchange(Some(onversionchange.as_ref().unchecked_ref()));
+        onversionchange.forget();
 
         Ok(Some(IdbStore {
             db: RwLock::new(db),


### PR DESCRIPTION
We now close the database if it is removed.

We do not yet update the JS Replicache object that the database got
closed. We can either:
 - Later calls to the database throws and we can then update the js
   state.
 - Add a callback

Towards #161