### PR TITLE
For discussion - deloop dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6854dd77ddc4f9ba1a448f487e27843583d407648150426a30c2ea3a2c39490a"
 
 [[package]]
+name = "instant"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +963,15 @@ name = "libc"
 version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1103,6 +1130,32 @@ name = "parking"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bcaa58ee64f8e4a3d02f5d8e6ed0340eae28fed6fdabd984ad1776e3b43848a"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1276,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "replicache-client"
-version = "0.1.0-REPLACE"
+version = "0.6.0-15-gf05ad47"
 dependencies = [
  "async-fn",
  "async-native-tls",
@@ -1309,6 +1362,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "wasm-timer",
  "web-sys",
 ]
 
@@ -1354,6 +1408,12 @@ name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
@@ -2004,6 +2064,21 @@ checksum = "2c2e18093f11c19ca4e188c177fecc7c372304c311189f12c2f9bea5b7324ac7"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "replicache-client"
-version = "0.1.0-REPLACE"
+version = "0.6.0-15-gf05ad47"
 authors = ["Rocicorp <replicache@roci.dev>"]
 edition = "2018"
 
@@ -28,6 +28,7 @@ sha2 = "0.8.1"
 str-macro = "0.1.4"
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = "0.4.13"
+wasm-timer = "0.2.5"
 
 [target.'cfg(not(target_env = "wasm"))'.dependencies]
 rand = "0.7.3"
@@ -74,7 +75,7 @@ features = [
 ]
 
 [lib]
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [profile.release]
 codegen-units = 1

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -1,0 +1,87 @@
+use crate::dag;
+use crate::kv;
+use crate::util::rlog::LogContext;
+use crate::util::uuid::uuid;
+use std::collections::HashMap;
+use std::marker::Send;
+use std::sync::Mutex;
+
+pub struct Connection {
+    store: dag::Store,
+    client_id: String,
+}
+
+unsafe impl Send for Connection {}
+
+type ConnMap = HashMap<String, Connection>;
+
+lazy_static! {
+    static ref CONNECTIONS: Mutex<ConnMap> = Mutex::new(HashMap::new());
+}
+
+#[derive(Debug)]
+pub enum OpenError {
+    DBNameMustBeNonEmpty,
+    InitClientIDError(InitClientIdError),
+    LockPoisoned,
+    NoKVStoreCreated,
+    OpenKVStoreError(kv::StoreError),
+}
+
+pub async fn open_database(db_name: String, lc: LogContext) -> Result<(), OpenError> {
+    use OpenError::*;
+
+    if db_name.is_empty() {
+        return Err(DBNameMustBeNonEmpty);
+    }
+
+    let mut lock = CONNECTIONS.lock().map_err(|_| LockPoisoned)?;
+    if lock.contains_key(&db_name) {
+        return Ok(());
+    }
+
+    let kv: Box<dyn kv::Store> = match db_name.as_str() {
+        #[cfg(not(target_arch = "wasm32"))]
+        "mem" => Box::new(kv::memstore::MemStore::new()),
+        _ => Box::new(
+            kv::idbstore::IdbStore::new(&db_name)
+                .await
+                .map_err(OpenKVStoreError)?
+                .ok_or(NoKVStoreCreated)?,
+        ),
+    };
+
+    let client_id = init_client_id(kv.as_ref(), lc)
+        .await
+        .map_err(InitClientIDError)?;
+    let store = dag::Store::new(kv);
+
+    lock.insert(db_name, Connection { client_id, store });
+    Ok(())
+}
+
+#[derive(Debug)]
+pub enum InitClientIdError {
+    CommitErr(kv::StoreError),
+    GetErr(kv::StoreError),
+    InvalidUtf8(std::string::FromUtf8Error),
+    OpenErr(kv::StoreError),
+    PutClientIdErr(kv::StoreError),
+}
+
+async fn init_client_id(s: &dyn kv::Store, lc: LogContext) -> Result<String, InitClientIdError> {
+    use InitClientIdError::*;
+    const CID_KEY: &str = "sys/cid";
+    let cid = s.get(CID_KEY).await.map_err(GetErr)?;
+    if let Some(cid) = cid {
+        let s = String::from_utf8(cid).map_err(InvalidUtf8)?;
+        return Ok(s);
+    }
+    let wt = s.write(lc).await.map_err(OpenErr)?;
+    let uuid = uuid();
+    wt.put(CID_KEY, &uuid.as_bytes())
+        .await
+        .map_err(PutClientIdErr)?;
+    wt.commit().await.map_err(CommitErr)?;
+    Ok(uuid)
+}

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -1,29 +1,121 @@
 use crate::dag;
+use crate::db;
+use crate::embed::types::{OpenTransactionRequest, OpenTransactionResponse};
+use crate::embed::{validate_rebase, OpenTransactionError};
 use crate::kv;
+use crate::util::rlog;
 use crate::util::rlog::LogContext;
 use crate::util::uuid::uuid;
+use async_std::sync::{Mutex, RwLock};
 use std::collections::HashMap;
 use std::marker::Send;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
 
-pub struct Connection {
+type ConnMap = HashMap<String, Connection>;
+type TxnMap = HashMap<u32, RwLock<Transaction>>;
+
+lazy_static! {
+    static ref CONNECTIONS: Mutex<ConnMap> = Mutex::new(HashMap::new());
+    static ref TRANSACTION_COUNTER: AtomicU32 = AtomicU32::new(1);
+}
+
+struct Connection {
     store: dag::Store,
     client_id: String,
+    transactions: RwLock<TxnMap>,
 }
 
 unsafe impl Send for Connection {}
 
-type ConnMap = HashMap<String, Connection>;
+impl Connection {
+    pub async fn open_transaction(
+        db_name: &str,
+        req: OpenTransactionRequest,
+        lc: &LogContext,
+    ) -> Result<OpenTransactionResponse, OpenTransactionError> {
+        use OpenTransactionError::*;
 
-lazy_static! {
-    static ref CONNECTIONS: Mutex<ConnMap> = Mutex::new(HashMap::new());
+        let guard = CONNECTIONS.lock().await;
+        let conn = guard.get(db_name).ok_or(DatabaseNotOpen)?;
+
+        let txn = match req.name {
+            Some(mutator_name) => {
+                let OpenTransactionRequest {
+                    name: _,
+                    args: mutator_args,
+                    rebase_opts,
+                } = req;
+                let mutator_args = mutator_args.ok_or(ArgsRequired)?;
+                let lock_timer = rlog::Timer::new().map_err(InternalTimerError)?;
+                debug!(lc, "Waiting for write lock...");
+                let dag_write = conn.store.write(lc.clone()).await.map_err(DagWriteError)?;
+                debug!(
+                    lc,
+                    "...Write lock acquired in {}ms",
+                    lock_timer.elapsed_ms()
+                );
+                let (whence, original_hash) = match rebase_opts {
+                    None => (db::Whence::Head(db::DEFAULT_HEAD_NAME.to_string()), None),
+                    Some(opts) => {
+                        validate_rebase(&opts, dag_write.read(), &mutator_name, &mutator_args)
+                            .await?;
+                        (db::Whence::Hash(opts.basis), Some(opts.original_hash))
+                    }
+                };
+
+                let write = db::Write::new_local(
+                    whence,
+                    mutator_name,
+                    mutator_args,
+                    original_hash,
+                    dag_write,
+                )
+                .await
+                .map_err(DBWriteError)?;
+                Transaction::Write(write)
+            }
+            None => {
+                let dag_read = conn.store.read(lc.clone()).await.map_err(DagReadError)?;
+                let read = db::OwnedRead::from_whence(
+                    db::Whence::Head(db::DEFAULT_HEAD_NAME.to_string()),
+                    dag_read,
+                )
+                .await
+                .map_err(DBReadError)?;
+                Transaction::Read(read)
+            }
+        };
+        let txn_id = TRANSACTION_COUNTER.fetch_add(1, Ordering::SeqCst);
+        /*
+        conn.transactions
+            .write()
+            .await
+            .insert(txn_id, RwLock::new(txn));
+            */
+        Ok(OpenTransactionResponse {
+            transaction_id: txn_id,
+        })
+    }
+}
+
+pub enum Transaction {
+    Read(db::OwnedRead<'static>),
+    Write(db::Write<'static>),
+}
+
+impl Transaction {
+    fn as_read(&self) -> db::Read {
+        match self {
+            Transaction::Read(r) => r.as_read(),
+            Transaction::Write(w) => w.as_read(),
+        }
+    }
 }
 
 #[derive(Debug)]
 pub enum OpenError {
     DBNameMustBeNonEmpty,
     InitClientIDError(InitClientIdError),
-    LockPoisoned,
     NoKVStoreCreated,
     OpenKVStoreError(kv::StoreError),
 }
@@ -35,7 +127,7 @@ pub async fn open_database(db_name: String, lc: LogContext) -> Result<(), OpenEr
         return Err(DBNameMustBeNonEmpty);
     }
 
-    let mut lock = CONNECTIONS.lock().map_err(|_| LockPoisoned)?;
+    let mut lock = CONNECTIONS.lock().await;
     if lock.contains_key(&db_name) {
         return Ok(());
     }
@@ -56,8 +148,20 @@ pub async fn open_database(db_name: String, lc: LogContext) -> Result<(), OpenEr
         .map_err(InitClientIDError)?;
     let store = dag::Store::new(kv);
 
-    lock.insert(db_name, Connection { client_id, store });
+    lock.insert(
+        db_name,
+        Connection {
+            client_id,
+            store,
+            transactions: RwLock::new(TxnMap::new()),
+        },
+    );
     Ok(())
+}
+
+pub async fn close_database(db_name: &str) {
+    let mut lock = CONNECTIONS.lock().await;
+    lock.remove(db_name);
 }
 
 #[derive(Debug)]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,6 @@
 mod commit;
 mod commit_generated;
+mod connection;
 mod read;
 mod root;
 mod scan;
@@ -14,6 +15,7 @@ pub use commit::{
     BaseSnapshotError, Commit, FromHashError, LocalMeta, MetaTyped, PendingError, ProgrammerError,
     DEFAULT_HEAD_NAME,
 };
+pub use connection::*;
 pub use read::{read_commit, OwnedRead, Read, ReadCommitError, Whence};
 pub use scan::{ScanBound, ScanKey, ScanOptions};
 pub use write::{init_db, CommitError, InitDBError, Write};

--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -295,7 +295,7 @@ async fn do_open_transaction<'a, 'b>(
     })
 }
 
-async fn validate_rebase<'a>(
+pub async fn validate_rebase<'a>(
     opts: &'a RebaseOpts,
     dag_read: dag::Read<'_>,
     mutator_name: &'a str,
@@ -528,10 +528,11 @@ enum GetRootError {
 
 #[derive(Debug)]
 #[allow(clippy::enum_variant_names)]
-enum OpenTransactionError {
+pub enum OpenTransactionError {
     ArgsRequired,
     DagWriteError(dag::Error),
     DagReadError(dag::Error),
+    DatabaseNotOpen,
     DBWriteError(db::ReadCommitError),
     DBReadError(db::ReadCommitError),
     GetHeadError(dag::Error),

--- a/src/embed/dispatch.rs
+++ b/src/embed/dispatch.rs
@@ -1,9 +1,11 @@
 use crate::dag;
+use crate::db;
 use crate::embed::connection;
 use crate::kv::idbstore::IdbStore;
 use crate::kv::{Store, StoreError};
 use crate::util::rlog;
 use crate::util::rlog::LogContext;
+use crate::util::to_debug::to_debug;
 use crate::util::uuid::uuid;
 use async_std::sync::{channel, Mutex, Receiver, Sender};
 use std::collections::HashMap;
@@ -99,6 +101,14 @@ pub async fn dispatch(db_name: String, rpc: String, data: String) -> Response {
 
     let result = match rpc.as_str() {
         "test" => do_test().await,
+        "open" => db::open_database(db_name, lc.clone())
+            .await
+            .map(|_| str!(""))
+            .map_err(to_debug),
+        "close" => {
+            db::close_database(&db_name).await;
+            Ok(str!(""))
+        }
         _ => {
             let (tx, rx) = channel::<Response>(1);
             let request = Request {

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -12,4 +12,5 @@ mod connection;
 mod dispatch;
 
 pub mod types;
+pub use connection::{validate_rebase, OpenTransactionError};
 pub use dispatch::dispatch;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod nanoserde;
 #[macro_use]
 pub mod rlog;
+pub mod to_debug;
 pub mod uuid;

--- a/src/util/to_debug/mod.rs
+++ b/src/util/to_debug/mod.rs
@@ -1,0 +1,13 @@
+use std::fmt::Debug;
+
+// Convenience trait to add to_debug() to a type which is std::fmt::Debug.
+pub trait ToDebug: Debug {
+    fn to_debug(&self) -> String {
+        to_debug(&self)
+    }
+}
+
+// Convenience bare function, useful for e.g., map() and map_err().
+pub fn to_debug<T: Debug>(thing: T) -> String {
+    format!("{:?}", thing)
+}


### PR DESCRIPTION
This PR doesn't work but shows my train of thought.

We change `dispatch` into a "normal" function that delegates directly to the "doer" functions. I already tested (see `do_test`) that the basic concept works -- the futures get executed and calls can overlap this way.

However, I rediscovered why we need the dispatch loop!

It's fundamentally because of the relationship between transactions and stores. Transactions have a reference to their store, so the store must outlive the transaction. In particular the `RWLockGuard` in `kv::{Read,Write}Transaction`.

My thought was that the RWLock would let us get around this, but it does not. What it weakens is the single writer requirement. The reference requirement remains.