### PR TITLE
Switch from optimizing for space to speed.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,9 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [profile.release]
 codegen-units = 1
 lto = true
-opt-level = "z"  # Optimize for size.
+# Optimize for speeeeed.
+# See https://github.com/rocicorp/repc/pull/198 for details as of time written.
+opt-level = 3
 panic = "abort"
 
 [package.metadata.wasm-pack.profile.release]


### PR DESCRIPTION
This increases scan performance on our benchmarks about 7%.

Summary of tradeoffs from my testing:

opt-level | size   |  Δsize | scan  | Δscan   | put clean | Δput clean | put dirty | Δput dirty |
----------|--------|--------|-------|---------|-----------|------------|-----------|------------|
z         | 143085 |  0.00% | 16.55 |   0.00% |      2.02 |      0.00% |      1.74 |      0.00% |
3         | 160698 | 12.31% | 17.69 |	6.89% |      2.50 |     23.76% |      2.88 |     65.52% |
2         | 158405 | 10.71% | 17.44 |   5.38% |      2.36 |     16.83% |      2.77 |     59.20% |
1         | 167348 | 16.96% |  8.03 | -51.48% |      0.79 |    -60.89% |      0.55 |    -68.39% |

Unclear how put-dirty somehow gets faster than put-clean under optimization.