### PR TITLE
For discussion - Serialize to unsafe view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "replicache-client"
-version = "0.1.0-REPLACE"
+version = "0.7.0-3-ga2cdb72"
 dependencies = [
  "async-fn",
  "async-native-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "replicache-client"
-version = "0.1.0-REPLACE"
+version = "0.7.0-3-ga2cdb72"
 authors = ["Rocicorp <replicache@roci.dev>"]
 edition = "2018"
 
@@ -75,7 +75,7 @@ features = [
 ]
 
 [lib]
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [profile.release]
 codegen-units = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 #[macro_use]
 pub mod util;
 
-#[cfg(not(target_arch = "wasm32"))]
-mod ffi;
-
+//#[cfg(not(target_arch = "wasm32"))]
+//mod ffi;
 pub mod wasm;
 
 extern crate async_std;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -194,6 +194,7 @@ pub enum BeginSyncError {
     ReadError(dag::Error),
     TimeTravelProhibited(String),
     WrongChecksum(String),
+    SerializeError(serde_json::error::Error),
 }
 
 pub async fn maybe_end_sync(
@@ -319,6 +320,7 @@ pub enum MaybeEndSyncError {
     WriteDefaultHeadError(dag::Error),
     WriteSyncHeadError(dag::Error),
     WrongSyncHeadJSLogInfo, // "JSLogInfo" is a signal to bindings to not log this alarmingly.
+    SerializeError(serde_json::error::Error),
 }
 
 #[derive(Debug, Default, PartialEq, Serialize)]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -16,12 +16,9 @@ pub async fn new_idbstore(name: String) -> Option<Box<dyn Store>> {
 }
 
 #[wasm_bindgen]
-pub async fn dispatch(db_name: String, rpc: String, args: String) -> Result<String, JsValue> {
+pub async fn dispatch(db_name: String, rpc: String, args: String) -> Result<JsValue, JsValue> {
     init_panic_hook();
-    match embed::dispatch(db_name, rpc, args).await {
-        Err(v) => Err(JsValue::from_str(&v[..])),
-        Ok(v) => Ok(v),
-    }
+    embed::dispatch(db_name, rpc, args).await
 }
 
 static INIT: Once = Once::new();

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -27,7 +27,7 @@ fn random_db() -> String {
 
 async fn dispatch(db: &str, rpc: &str, data: &str) -> Result<String, String> {
     match wasm::dispatch(db.to_string(), rpc.to_string(), data.to_string()).await {
-        Ok(v) => Ok(v),
+        Ok(v) => Ok(v.as_string().unwrap()),
         Err(v) => Err(v.as_string().unwrap()),
     }
 }
@@ -187,31 +187,6 @@ async fn test_open_close() {
     );
     assert_eq!(dispatch("db2", "close", "").await.unwrap(), "");
     assert_eq!(dispatch("", "debug", "open_dbs").await.unwrap(), "[]");
-}
-
-#[wasm_bindgen_test]
-async fn test_drop() {
-    assert_eq!(dispatch("db", "open", "").await.unwrap(), "");
-    assert_eq!(dispatch("", "debug", "open_dbs").await.unwrap(), "[\"db\"]");
-
-    let txn_id = open_transaction("db", "foo".to_string().into(), Some(json!([])), None)
-        .await
-        .transaction_id;
-    put("db", txn_id, "value", "1").await;
-    commit("db", txn_id).await.unwrap();
-
-    assert_eq!(dispatch("db", "close", "").await.unwrap(), "");
-
-    // drop db
-    assert_eq!(dispatch("db", "drop", "").await.unwrap(), "");
-
-    // re-open, should be empty
-    assert_eq!(dispatch("db", "open", "").await.unwrap(), "");
-    let txn_id = open_transaction("db", None, None, None)
-        .await
-        .transaction_id;
-    assert_eq!(has("db", txn_id, "foo").await, false);
-    assert_eq!(dispatch("db", "close", "").await.unwrap(), "");
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
Only the last commit is interesting. I had originally thought I'd return batches of ArrayBuffers back to client but cannot because that would cause allocations after Uint8Array::view() which can invalidate them.