### PR TITLE
Cleanup connection.rs 

### DIFF
--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -157,6 +157,7 @@ impl<'a, 'b> Context<'a, 'b> {
 }
 
 #[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
 enum ExecuteError {
     TransactionNotFound(u32),
     TransactionRequired,
@@ -415,13 +416,13 @@ async fn do_get_root<'a, 'b>(
     })
 }
 
-async fn do_has<'a>(txn: db::Read<'a>, req: HasRequest) -> Result<HasResponse, ()> {
+async fn do_has(txn: db::Read<'_>, req: HasRequest) -> Result<HasResponse, ()> {
     Ok(HasResponse {
         has: txn.has(req.key.as_bytes()),
     })
 }
 
-async fn do_get<'a>(read: db::Read<'a>, req: GetRequest) -> Result<GetResponse, String> {
+async fn do_get(read: db::Read<'_>, req: GetRequest) -> Result<GetResponse, String> {
     #[cfg(not(default))] // Not enabled in production.
     if req.key.starts_with("sleep") {
         use async_std::task::sleep;
@@ -448,7 +449,7 @@ async fn do_get<'a>(read: db::Read<'a>, req: GetRequest) -> Result<GetResponse, 
     })
 }
 
-async fn do_scan<'a>(read: db::Read<'a>, req: ScanRequest) -> Result<ScanResponse, String> {
+async fn do_scan(read: db::Read<'_>, req: ScanRequest) -> Result<ScanResponse, String> {
     use std::convert::TryFrom;
     let mut res = Vec::<ScanItem>::new();
     for pe in read.scan((&req.opts).into()) {
@@ -457,12 +458,12 @@ async fn do_scan<'a>(read: db::Read<'a>, req: ScanRequest) -> Result<ScanRespons
     Ok(ScanResponse { items: res })
 }
 
-async fn do_put<'a>(write: &mut db::Write<'a>, req: PutRequest) -> Result<PutResponse, ()> {
+async fn do_put(write: &mut db::Write<'_>, req: PutRequest) -> Result<PutResponse, ()> {
     write.put(req.key.as_bytes().to_vec(), req.value.into_bytes());
     Ok(PutResponse {})
 }
 
-async fn do_del<'a>(write: &mut db::Write<'a>, req: DelRequest) -> Result<DelResponse, ()> {
+async fn do_del(write: &mut db::Write<'_>, req: DelRequest) -> Result<DelResponse, ()> {
     let had = write.as_read().has(req.key.as_bytes());
     write.del(req.key.as_bytes().to_vec());
     Ok(DelResponse { had })

--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -131,7 +131,7 @@ where
     S: serde::Serialize,
     F: for<'r, 's> AsyncFn3<&'r RwLock<Transaction<'s>>, T, LogContext, Output = Result<S, String>>,
 {
-    let request: T = match deserialize(&req.data) {
+    let request: T = match deserialize(&req.data.as_string().unwrap()) {
         Ok(v) => v,
         Err(e) => return req.response.send(Err(e)).await,
     };
@@ -193,7 +193,7 @@ where
     E: std::fmt::Debug,
     F: AsyncFn2<Context<'a, 'b>, T, Output = Result<S, E>>,
 {
-    let request: T = match deserialize(&req.data) {
+    let request: T = match deserialize(&req.data.as_string().unwrap()) {
         Ok(v) => v,
         Err(e) => return req.response.send(Err(e)).await,
     };

--- a/src/embed/dispatch.rs
+++ b/src/embed/dispatch.rs
@@ -82,7 +82,8 @@ async fn dispatch_loop(rx: Receiver<Request>) {
     }
 }
 
-pub async fn dispatch(db_name: String, rpc: String, data: String) -> Response {
+pub async fn dispatch(db_name: String, rpc: String, data: wasm_bindgen::JsValue) -> Response {
+    let data = data.as_string().unwrap();
     let lc = LogContext::new();
     let rpc_id = RPC_COUNTER.fetch_add(1, Ordering::Relaxed).to_string();
     lc.add_context("rpc_id", rpc_id.as_str());

--- a/src/embed/types.rs
+++ b/src/embed/types.rs
@@ -52,6 +52,13 @@ pub struct CloseTransactionRequest {
 #[derive(Serialize)]
 pub struct CloseTransactionResponse {}
 
+#[derive(Deserialize, Serialize)]
+pub struct TransactionRequest {
+    #[serde(rename = "transactionId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_id: Option<u32>,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct GetRootRequest {
     #[serde(rename = "headName")]
@@ -66,8 +73,6 @@ pub struct GetRootResponse {
 
 #[derive(Deserialize)]
 pub struct HasRequest {
-    #[serde(rename = "transactionId")]
-    pub transaction_id: u32,
     pub key: String,
 }
 
@@ -78,8 +83,6 @@ pub struct HasResponse {
 
 #[derive(Deserialize)]
 pub struct GetRequest {
-    #[serde(rename = "transactionId")]
-    pub transaction_id: u32,
     pub key: String,
 }
 
@@ -140,8 +143,6 @@ impl<'a> From<&'a ScanOptions> for db::ScanOptions<'a> {
 
 #[derive(Deserialize)]
 pub struct ScanRequest {
-    #[serde(rename = "transactionId")]
-    pub transaction_id: u32,
     pub opts: ScanOptions,
 }
 
@@ -174,8 +175,6 @@ pub struct ScanResponse {
 
 #[derive(Deserialize)]
 pub struct PutRequest {
-    #[serde(rename = "transactionId")]
-    pub transaction_id: u32,
     pub key: String,
     pub value: String,
 }
@@ -185,8 +184,6 @@ pub struct PutResponse {}
 
 #[derive(Deserialize)]
 pub struct DelRequest {
-    #[serde(rename = "transactionId")]
-    pub transaction_id: u32,
     pub key: String,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 pub mod util;
 
-#[cfg(not(target_arch = "wasm32"))]
-mod ffi;
+//#[cfg(not(target_arch = "wasm32"))]
+//mod ffi;
 
 pub mod wasm;
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -16,7 +16,7 @@ pub async fn new_idbstore(name: String) -> Option<Box<dyn Store>> {
 }
 
 #[wasm_bindgen]
-pub async fn dispatch(db_name: String, rpc: String, args: String) -> Result<String, JsValue> {
+pub async fn dispatch(db_name: String, rpc: String, args: JsValue) -> Result<String, JsValue> {
     init_panic_hook();
     match embed::dispatch(db_name, rpc, args).await {
         Err(v) => Err(JsValue::from_str(&v[..])),

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -196,31 +196,6 @@ async fn test_open_close() {
 }
 
 #[wasm_bindgen_test]
-async fn test_drop() {
-    assert_eq!(dispatch("db", "open", "").await.unwrap(), "");
-    assert_eq!(dispatch("", "debug", "open_dbs").await.unwrap(), "[\"db\"]");
-
-    let txn_id = open_transaction("db", "foo".to_string().into(), Some(json!([])), None)
-        .await
-        .transaction_id;
-    put("db", txn_id, "value", "1").await;
-    commit("db", txn_id).await.unwrap();
-
-    assert_eq!(dispatch("db", "close", "").await.unwrap(), "");
-
-    // drop db
-    assert_eq!(dispatch("db", "drop", "").await.unwrap(), "");
-
-    // re-open, should be empty
-    assert_eq!(dispatch("db", "open", "").await.unwrap(), "");
-    let txn_id = open_transaction("db", None, None, None)
-        .await
-        .transaction_id;
-    assert_eq!(has("db", txn_id, "foo").await, false);
-    assert_eq!(dispatch("db", "close", "").await.unwrap(), "");
-}
-
-#[wasm_bindgen_test]
 async fn test_dispatch_concurrency() {
     let db = &random_db();
     let window = web_sys::window().expect("should have a window in this context");

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -26,7 +26,13 @@ fn random_db() -> String {
 }
 
 async fn dispatch(db: &str, rpc: &str, data: &str) -> Result<String, String> {
-    match wasm::dispatch(db.to_string(), rpc.to_string(), data.to_string()).await {
+    match wasm::dispatch(
+        db.to_string(),
+        rpc.to_string(),
+        wasm_bindgen::JsValue::from_str(data),
+    )
+    .await
+    {
         Ok(v) => Ok(v),
         Err(v) => Err(v.as_string().unwrap()),
     }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -290,7 +290,7 @@ async fn test_get_put_del() {
     // Check request parsing, both missing and unexpected fields.
     assert_eq!(
         dispatch(db, "put", "{}").await.unwrap_err(),
-        "InvalidJson(missing field `transactionId` at line 1 column 2)"
+        "TransactionRequired"
     );
 
     let txn_id = open_transaction(db, "foo".to_string().into(), Some(json!([])), None)


### PR DESCRIPTION
Rework connection.rs to make it a bit easier to work with.
    
This isn't an architectural rethink, just mechanical cleaning. The main thing I wanted to achieve was:
    
- reduce duplication between execute() and execute_in_txn()
- reduce coupling of "doer" functions to json inputs, so that scan can take a js function as an argument to call as a perf improvement.

No perf impact from this PR. Reduced binary size by about 5k though.

(commits can be reviewed independently)