### PR TITLE
Switch to Cloudflare's serde-wasm-bindgen for serialization to/from JS.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,6 +1285,7 @@ dependencies = [
  "rand",
  "regex",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "sha2 0.8.2",
  "str-macro",
@@ -1391,6 +1392,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee6f12f7ed0e7ad2e55200da37dbabc2cadeb942355c5b629aa3771f5ac5636"
+dependencies = [
+ "fnv",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ maplit = "1.0.2"
 sha2 = "0.8.1"
 serde = "1.0.116"
 serde_json = "1.0"
+serde-wasm-bindgen = "0.1.3"
 str-macro = "0.1.4"
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = "0.4.13"

--- a/src/db/read.rs
+++ b/src/db/read.rs
@@ -108,7 +108,7 @@ mod tests {
         let mut w = write::Write::new_local(
             Whence::Head(str!(db::DEFAULT_HEAD_NAME)),
             str!("mutator_name"),
-            serde_json::Value::Array(vec![]),
+            serde_json::Value::Array(vec![]).to_string(),
             None,
             ds.write(LogContext::new()).await.unwrap(),
         )

--- a/src/db/test_helpers.rs
+++ b/src/db/test_helpers.rs
@@ -34,7 +34,7 @@ pub async fn add_local<'a>(chain: &'a mut Chain, store: &dag::Store) -> &'a mut 
     let mut w = Write::new_local(
         Whence::Head(str!(db::DEFAULT_HEAD_NAME)),
         format!("mutator_name_{}", i),
-        json!([i]),
+        json!([i]).to_string(),
         None,
         store.write(LogContext::new()).await.unwrap(),
     )

--- a/src/db/write.rs
+++ b/src/db/write.rs
@@ -13,7 +13,7 @@ enum Meta {
 
 struct LocalMeta {
     mutator_name: String,
-    mutator_args: serde_json::Value,
+    mutator_args: String,
     mutation_id: u64,
     original_hash: Option<String>,
 }
@@ -64,7 +64,7 @@ impl<'a> Write<'a> {
     pub async fn new_local(
         whence: Whence,
         mutator_name: String,
-        mutator_args: serde_json::Value,
+        mutator_args: String,
         original_hash: Option<String>,
         dag_write: dag::Write<'a>,
     ) -> Result<Write<'a>, ReadCommitError> {
@@ -175,7 +175,7 @@ impl<'a> Write<'a> {
                     self.checksum,
                     mutation_id,
                     &mutator_name,
-                    &serde_json::to_vec(&mutator_args).map_err(SerializeArgsError)?,
+                    mutator_args.as_bytes(),
                     original_hash.as_deref(),
                     &value_hash,
                 )
@@ -243,7 +243,7 @@ mod tests {
         let mut w = Write::new_local(
             Whence::Head(str!(db::DEFAULT_HEAD_NAME)),
             str!("mutator_name"),
-            serde_json::Value::Array(vec![]),
+            serde_json::Value::Array(vec![]).to_string(),
             None,
             ds.write(LogContext::new()).await.unwrap(),
         )
@@ -257,7 +257,7 @@ mod tests {
         let w = Write::new_local(
             Whence::Head(str!(db::DEFAULT_HEAD_NAME)),
             str!("mutator_name"),
-            serde_json::Value::Null,
+            serde_json::Value::Null.to_string(),
             None,
             ds.write(LogContext::new()).await.unwrap(),
         )
@@ -281,7 +281,7 @@ mod tests {
         let mut w = Write::new_local(
             Whence::Head(str!(db::DEFAULT_HEAD_NAME)),
             str!("mutator_name"),
-            serde_json::Value::Array(vec![]),
+            serde_json::Value::Array(vec![]).to_string(),
             None,
             ds.write(LogContext::new()).await.unwrap(),
         )

--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -36,24 +36,24 @@ impl<'a> Transaction<'a> {
 type TxnMap<'a> = RwLock<HashMap<u32, RwLock<Transaction<'a>>>>;
 
 #[derive(Debug)]
-enum FromJsonError {
+enum FromJsError {
     DeserializeError(serde_wasm_bindgen::Error),
 }
 
-fn from_json<T: serde::de::DeserializeOwned>(data: JsValue) -> Result<T, String> {
-    use FromJsonError::*;
+fn from_js<T: serde::de::DeserializeOwned>(data: JsValue) -> Result<T, String> {
+    use FromJsError::*;
     serde_wasm_bindgen::from_value(data)
         .map_err(DeserializeError)
         .map_err(to_debug)
 }
 
 #[derive(Debug)]
-enum ToJsonError {
+enum ToJsError {
     SerializeError(serde_wasm_bindgen::Error),
 }
 
-fn to_json<T: serde::Serialize, E: std::fmt::Debug>(res: Result<T, E>) -> Result<JsValue, JsValue> {
-    use ToJsonError::*;
+fn to_js<T: serde::Serialize, E: std::fmt::Debug>(res: Result<T, E>) -> Result<JsValue, JsValue> {
+    use ToJsError::*;
     match res {
         Ok(v) => Ok(serde_wasm_bindgen::to_value(&v)
             .map_err(SerializeError)
@@ -181,17 +181,17 @@ async fn execute<'a, 'b>(
 
     // transaction-less
     match rpc.as_str() {
-        "getRoot" => return to_json(do_get_root(ctx, from_json(data)?).await),
-        "openTransaction" => return to_json(do_open_transaction(ctx, from_json(data)?).await),
-        "commitTransaction" => return to_json(do_commit(ctx, from_json(data)?).await),
-        "closeTransaction" => return to_json(do_close(ctx, from_json(data)?).await),
-        "beginSync" => return to_json(do_begin_sync(ctx, from_json(data)?).await),
-        "maybeEndSync" => return to_json(do_maybe_end_sync(ctx, from_json(data)?).await),
+        "getRoot" => return to_js(do_get_root(ctx, from_js(data)?).await),
+        "openTransaction" => return to_js(do_open_transaction(ctx, from_js(data)?).await),
+        "commitTransaction" => return to_js(do_commit(ctx, from_js(data)?).await),
+        "closeTransaction" => return to_js(do_close(ctx, from_js(data)?).await),
+        "beginSync" => return to_js(do_begin_sync(ctx, from_js(data)?).await),
+        "maybeEndSync" => return to_js(do_maybe_end_sync(ctx, from_js(data)?).await),
         _ => (),
     };
 
     // require read txn
-    let txn_req: TransactionRequest = from_json(data.clone())?;
+    let txn_req: TransactionRequest = from_js(data.clone())?;
     let txn_id = txn_req
         .transaction_id
         .ok_or(TransactionRequired)
@@ -205,9 +205,9 @@ async fn execute<'a, 'b>(
         .map_err(to_debug)?;
 
     match rpc.as_str() {
-        "has" => return to_json(do_has(txn.read().await.as_read(), from_json(data)?).await),
-        "get" => return to_json(do_get(txn.read().await.as_read(), from_json(data)?).await),
-        "scan" => return to_json(do_scan(txn.read().await.as_read(), from_json(data)?).await),
+        "has" => return to_js(do_has(txn.read().await.as_read(), from_js(data)?).await),
+        "get" => return to_js(do_get(txn.read().await.as_read(), from_js(data)?).await),
+        "scan" => return to_js(do_scan(txn.read().await.as_read(), from_js(data)?).await),
         _ => (),
     }
 
@@ -219,8 +219,8 @@ async fn execute<'a, 'b>(
     }?;
 
     match rpc.as_str() {
-        "put" => return to_json(do_put(write, from_json(data)?).await),
-        "del" => return to_json(do_del(write, from_json(data)?).await),
+        "put" => return to_js(do_put(write, from_js(data)?).await),
+        "del" => return to_js(do_del(write, from_js(data)?).await),
         _ => (),
     }
 

--- a/src/embed/types.rs
+++ b/src/embed/types.rs
@@ -4,16 +4,16 @@ use crate::db;
 use crate::prolly;
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct OpenTransactionRequest {
-    pub name: Option<String>,            // not present in read transactions
-    pub args: Option<serde_json::Value>, // not present in read transactions
+    pub name: Option<String>, // not present in read transactions
+    pub args: Option<String>, // not present in read transactions
     #[serde(rename = "rebaseOpts")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rebase_opts: Option<RebaseOpts>,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RebaseOpts {
     pub basis: String,
     #[serde(rename = "original")]
@@ -26,13 +26,13 @@ pub struct OpenTransactionResponse {
     pub transaction_id: u32,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CommitTransactionRequest {
     #[serde(rename = "transactionId")]
     pub transaction_id: u32,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CommitTransactionResponse {
     // Note: the field is named "ref" in go but "ref" is a reserved word in rust.
     #[serde(rename = "ref")]
@@ -43,16 +43,16 @@ pub struct CommitTransactionResponse {
     pub retry_commit: bool,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CloseTransactionRequest {
     #[serde(rename = "transactionId")]
     pub transaction_id: u32,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CloseTransactionResponse {}
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct TransactionRequest {
     #[serde(rename = "transactionId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -66,37 +66,41 @@ pub struct GetRootRequest {
     pub head_name: Option<String>,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct GetRootResponse {
     pub root: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct HasRequest {
+    #[serde(rename = "transactionId")]
+    pub transaction_id: u32,
     pub key: String,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct HasResponse {
     pub has: bool,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct GetRequest {
+    #[serde(rename = "transactionId")]
+    pub transaction_id: u32,
     pub key: String,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct GetResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
     pub has: bool, // Second to avoid trailing comma if value == None.
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ScanKey {
-    value: String,
-    exclusive: bool,
+    pub value: String,
+    pub exclusive: bool,
 }
 
 impl<'a> From<&'a ScanKey> for db::ScanKey<'a> {
@@ -108,11 +112,11 @@ impl<'a> From<&'a ScanKey> for db::ScanKey<'a> {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ScanBound {
     #[serde(rename = "id")]
-    key: Option<ScanKey>,
-    index: Option<u64>,
+    pub key: Option<ScanKey>,
+    pub index: Option<u64>,
 }
 
 impl<'a> From<&'a ScanBound> for db::ScanBound<'a> {
@@ -124,11 +128,11 @@ impl<'a> From<&'a ScanBound> for db::ScanBound<'a> {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ScanOptions {
-    prefix: Option<String>,
-    start: Option<ScanBound>,
-    limit: Option<u64>,
+    pub prefix: Option<String>,
+    pub start: Option<ScanBound>,
+    pub limit: Option<u64>,
 }
 
 impl<'a> From<&'a ScanOptions> for db::ScanOptions<'a> {
@@ -141,15 +145,17 @@ impl<'a> From<&'a ScanOptions> for db::ScanOptions<'a> {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ScanRequest {
+    #[serde(rename = "transactionId")]
+    pub transaction_id: u32,
     pub opts: ScanOptions,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct ScanItem {
-    key: String,
-    value: String,
+    pub key: String,
+    pub value: String,
 }
 
 #[derive(Debug)]
@@ -168,26 +174,30 @@ impl<'a> std::convert::TryFrom<prolly::Entry<'a>> for ScanItem {
     type Error = FromProllyEntryError;
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct ScanResponse {
     pub items: Vec<ScanItem>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PutRequest {
+    #[serde(rename = "transactionId")]
+    pub transaction_id: u32,
     pub key: String,
     pub value: String,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PutResponse {}
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DelRequest {
+    #[serde(rename = "transactionId")]
+    pub transaction_id: u32,
     pub key: String,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DelResponse {
     #[serde(rename = "ok")]
     pub had: bool,

--- a/src/sync/types.rs
+++ b/src/sync/types.rs
@@ -58,6 +58,6 @@ pub struct MaybeEndSyncResponse {
 pub struct ReplayMutation {
     pub id: u64,
     pub name: String,
-    pub args: serde_json::Value,
+    pub args: String,
     pub original: String,
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -16,12 +16,9 @@ pub async fn new_idbstore(name: String) -> Option<Box<dyn Store>> {
 }
 
 #[wasm_bindgen]
-pub async fn dispatch(db_name: String, rpc: String, args: JsValue) -> Result<String, JsValue> {
+pub async fn dispatch(db_name: String, rpc: String, args: JsValue) -> Result<JsValue, JsValue> {
     init_panic_hook();
-    match embed::dispatch(db_name, rpc, args).await {
-        Err(v) => Err(JsValue::from_str(&v[..])),
-        Ok(v) => Ok(v),
-    }
+    embed::dispatch(db_name, rpc, args).await
 }
 
 static INIT: Once = Once::new();


### PR DESCRIPTION
This goes back and forth via the JS API rather than via JSON.

Reduce binary size by ~5%
Increase scan perf by: ~23%

```
replicache_client.js: 24114
replicache_client.js.br: 4515
replicache_client_bg.wasm: 517109
replicache_client_bg.wasm.br: 149832

Running benchmarks please wait...
populate 1024x1000 (clean) x 1.73 MB/s ±0.0% (0 runs sampled)
populate 1024x1000 (dirty) x 1.72 MB/s ±0.0% (0 runs sampled)
scan 1024x1000 x 22.19 MB/s ±0.0% (0 runs sampled)
scan 1024x5000 x 21.42 MB/s ±0.0% (0 runs sampled)
Done!
```