### PR TITLE
Implement Garbage Collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5444eec77a9ec2bfe4524139e09195862e981400c4358d3b760cae634e4c4ee"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-sse"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,6 +1276,7 @@ version = "0.1.0-REPLACE"
 dependencies = [
  "async-fn",
  "async-native-tls",
+ "async-recursion",
  "async-std",
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ benchmark = []
 
 [dependencies]
 async-fn = { path = "crates/async-fn" }
+async-recursion = "0.3.1"
 async-std = { version = "=1.6.0", features = ["unstable"] }
 async-trait = "0.1.36"
 console_log = { version = "0.2" }

--- a/src/dag/key.rs
+++ b/src/dag/key.rs
@@ -7,6 +7,7 @@ use std::str;
 pub enum Key<'a> {
     ChunkData(&'a str),
     ChunkMeta(&'a str),
+    ChunkRefCount(&'a str),
     Head(&'a str),
 }
 
@@ -30,6 +31,7 @@ impl<'a> Key<'_> {
                 match suffix {
                     "d" => Ok(Key::ChunkData(content)),
                     "m" => Ok(Key::ChunkMeta(content)),
+                    "r" => Ok(Key::ChunkRefCount(content)),
                     _ => Err(()),
                 }
             }
@@ -44,6 +46,7 @@ impl<'a> fmt::Display for Key<'a> {
         match self {
             Key::ChunkData(hash) => write!(f, "c/{}/d", hash),
             Key::ChunkMeta(hash) => write!(f, "c/{}/m", hash),
+            Key::ChunkRefCount(hash) => write!(f, "c/{}/r", hash),
             Key::Head(name) => write!(f, "h/{}", name),
         }
     }
@@ -64,6 +67,9 @@ mod tests {
         test(&Key::ChunkMeta(""), "c//m");
         test(&Key::ChunkMeta("a"), "c/a/m");
         test(&Key::ChunkMeta("ab"), "c/ab/m");
+        test(&Key::ChunkRefCount(""), "c//r");
+        test(&Key::ChunkRefCount("a"), "c/a/r");
+        test(&Key::ChunkRefCount("ab"), "c/ab/r");
         test(&Key::Head(""), "h/");
         test(&Key::Head("a"), "h/a");
         test(&Key::Head("ab"), "h/ab");
@@ -87,6 +93,9 @@ mod tests {
         test(Ok(Key::ChunkMeta("")), "c//m");
         test(Ok(Key::ChunkMeta("a")), "c/a/m");
         test(Ok(Key::ChunkMeta("ab")), "c/ab/m");
+        test(Ok(Key::ChunkRefCount("")), "c//r");
+        test(Ok(Key::ChunkRefCount("a")), "c/a/r");
+        test(Ok(Key::ChunkRefCount("ab")), "c/ab/r");
         test(Ok(Key::Head("")), "h/");
         test(Ok(Key::Head("a")), "h/a");
         test(Ok(Key::Head("ab")), "h/ab");
@@ -99,6 +108,8 @@ mod tests {
             Key::ChunkData("a".into()),
             Key::ChunkMeta("".into()),
             Key::ChunkMeta("a".into()),
+            Key::ChunkRefCount("".into()),
+            Key::ChunkRefCount("a".into()),
             Key::Head("".into()),
             Key::Head("a".into()),
         ];

--- a/src/dag/write.rs
+++ b/src/dag/write.rs
@@ -6,8 +6,8 @@ use async_recursion::async_recursion;
 use async_std::sync::RwLock;
 use futures::future::try_join_all;
 use futures::try_join;
-use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 use str_macro::str;
 
@@ -79,10 +79,13 @@ impl<'a> Write<'_> {
             Entry::Occupied(mut entry) => {
                 // Keep old if occupied.
                 entry.get_mut().new = hash.map(str::to_string);
-            },
+            }
             Entry::Vacant(entry) => {
-                entry.insert(HeadChange{new: hash.map(str::to_string), old: old_hash});
-            },
+                entry.insert(HeadChange {
+                    new: hash.map(str::to_string),
+                    old: old_hash,
+                });
+            }
         }
 
         Ok(())

--- a/src/dag/write.rs
+++ b/src/dag/write.rs
@@ -1,15 +1,35 @@
-use super::chunk::Chunk;
 use super::key::Key;
+use super::{chunk::Chunk, meta_generated::meta};
 use super::{read, Result};
 use crate::kv;
+use async_recursion::async_recursion;
+use async_std::sync::RwLock;
+use futures::future::try_join_all;
+use futures::try_join;
+use std::collections::HashSet;
+
+#[derive(Debug, Default)]
+struct HeadChange(Option<String>, Option<String>);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum RefCount {
+    Inc = 1,
+    Dec = -1,
+}
 
 pub struct Write<'a> {
     kvw: Box<dyn kv::Write + 'a>,
+    changed_heads: RwLock<Vec<HeadChange>>,
+    mutated_chunks: RwLock<HashSet<String>>,
 }
 
 impl<'a> Write<'_> {
     pub fn new(kvw: Box<dyn kv::Write + 'a>) -> Write {
-        Write { kvw }
+        Write {
+            kvw,
+            changed_heads: Default::default(),
+            mutated_chunks: Default::default(),
+        }
     }
 
     pub fn read(&self) -> read::Read {
@@ -17,28 +37,47 @@ impl<'a> Write<'_> {
     }
 
     pub async fn put_chunk(&mut self, c: &Chunk) -> Result<()> {
+        // TODO: These can be done in parallel.
+
         self.kvw
             .put(&Key::ChunkData(c.hash()).to_string(), c.data())
             .await?;
+
         if let Some(meta) = c.meta() {
             self.kvw
                 .put(&Key::ChunkMeta(c.hash()).to_string(), meta)
                 .await?;
         }
+
+        self.mutated_chunks
+            .write()
+            .await
+            .insert(c.hash().to_string());
+
         Ok(())
     }
 
     pub async fn set_head(&mut self, name: &str, hash: Option<&str>) -> Result<()> {
+        let old_hash = self.read().get_head(name).await?;
+
+        // TODO: These can be done in parallel.
+
+        let head_key = Key::Head(name).to_string();
         match hash {
-            None => Ok(self.kvw.del(&Key::Head(name).to_string()).await?),
-            Some(h) => Ok(self
-                .kvw
-                .put(&Key::Head(name).to_string(), h.as_bytes())
-                .await?),
+            None => self.kvw.del(&head_key).await?,
+            Some(h) => self.kvw.put(&head_key, h.as_bytes()).await?,
         }
+
+        self.changed_heads
+            .write()
+            .await
+            .push(HeadChange(hash.map(str::to_string), old_hash));
+
+        Ok(())
     }
 
     pub async fn commit(self) -> Result<()> {
+        self.collect_garbage().await?;
         Ok(self.kvw.commit().await?)
     }
 
@@ -46,10 +85,111 @@ impl<'a> Write<'_> {
     pub async fn rollback(self) -> Result<()> {
         Ok(self.kvw.rollback().await?)
     }
+
+    async fn set_ref_count(&self, hash: &str, count: u16) -> Result<()> {
+        // Ref count is represented as a u16 stored as 2 bytes using BE.
+        let ref_count_key = Key::ChunkRefCount(hash).to_string();
+        let buf = count.to_be_bytes();
+        if count == 0u16 {
+            self.kvw.del(&ref_count_key).await?;
+        } else {
+            self.kvw.put(&ref_count_key, &buf).await?;
+        }
+        Ok(())
+    }
+
+    async fn get_ref_count(&self, hash: &str) -> Result<u16> {
+        let buf = self.kvw.get(&Key::ChunkRefCount(hash).to_string()).await?;
+        Ok(match buf {
+            None => 0u16,
+            Some(buf) => u16::from_be_bytes([buf[0], buf[1]]),
+        })
+    }
+
+    #[async_recursion(?Send)]
+    async fn change_ref_count(&self, hash: &str, rc: RefCount) -> Result<()> {
+        let old_count = self.get_ref_count(hash).await?;
+        let new_count = (old_count as i32) + (rc as i32);
+
+        if old_count == 0 && rc == RefCount::Inc || old_count == 1 && rc == RefCount::Dec {
+            let meta_key = Key::ChunkMeta(hash).to_string();
+            let buf = self.kvw.get(&meta_key).await?;
+            if let Some(buf) = buf {
+                let meta = meta::get_root_as_meta(&buf);
+                if let Some(refs) = meta.refs() {
+                    for r in refs.iter() {
+                        self.change_ref_count(r, rc).await?;
+                    }
+                }
+            }
+        }
+
+        if new_count == 0 {
+            self.remove_all_related_keys(hash, true).await?;
+        } else {
+            self.set_ref_count(hash, new_count as u16).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn remove_all_related_keys(&self, hash: &str, update_mutated_chunks: bool) -> Result<()> {
+        let data_key = Key::ChunkData(hash).to_string();
+        let meta_key = Key::ChunkMeta(hash).to_string();
+        let ref_count_key = Key::ChunkRefCount(hash).to_string();
+
+        try_join!(
+            self.kvw.del(&data_key),
+            self.kvw.del(&meta_key),
+            self.kvw.del(&ref_count_key),
+        )?;
+
+        // TODO: Getting the write lock could be done in parallel too.
+
+        if update_mutated_chunks {
+            let mut mutated_chunks = self.mutated_chunks.write().await;
+            mutated_chunks.remove(hash);
+        }
+        Ok(())
+    }
+
+    async fn collect_garbage(&self) -> Result<()> {
+        // We increment all the ref counts before we do all the decrements. This
+        // is so that we do not remove an item that goes from 1 -> 0 -> 1
+
+        let changed_heads = self.changed_heads.read().await;
+        let (new, old): (Vec<Option<&str>>, Vec<Option<&str>>) = changed_heads
+            .iter()
+            .map(|HeadChange(new, old)| (new.as_deref(), old.as_deref()))
+            .unzip();
+
+        for n in new.iter().filter_map(Option::as_ref) {
+            self.change_ref_count(n, RefCount::Inc).await?;
+        }
+
+        for o in old.iter().filter_map(Option::as_ref) {
+            self.change_ref_count(o, RefCount::Dec).await?;
+        }
+
+        // Now we go through the mutated chunks to see if any of them are still orphaned.
+        let mutated_chunks = self.mutated_chunks.read().await;
+        try_join_all(mutated_chunks.iter().map(|hash| async move {
+            let count = self.get_ref_count(&hash).await?;
+            if count == 0u16 {
+                self.remove_all_related_keys(&hash, false).await?;
+            }
+            Ok(()) as Result<()>
+        }))
+        .await?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use kv::Read;
+
     use super::*;
     use crate::kv::memstore::MemStore;
     use crate::kv::Store;
@@ -60,7 +200,7 @@ mod tests {
         async fn test(data: &[u8], refs: &[&str]) {
             let kv = MemStore::new();
             let kvw = kv.write(LogContext::new()).await.unwrap();
-            let mut w = Write { kvw };
+            let mut w = Write::new(kvw);
 
             let c = Chunk::new((data.to_vec(), 0), refs);
             w.put_chunk(&c).await.unwrap();
@@ -87,12 +227,26 @@ mod tests {
         test(&vec![0, 1], &vec!["r1", "r2"]).await;
     }
 
+    async fn assert_ref_count(kvr: &dyn Read, hash: &str, count: u16) {
+        let buf = kvr
+            .get(&Key::ChunkRefCount(hash).to_string())
+            .await
+            .unwrap();
+        if count == 0 {
+            assert!(buf.is_none());
+        } else {
+            let buf = buf.unwrap();
+            let m_count = ((buf[0] as u16) << 8) + (buf[1] as u16);
+            assert_eq!(m_count, count);
+        }
+    }
+
     #[async_std::test]
     async fn set_head() {
-        async fn test(name: &str, hash: Option<&str>) {
-            let kv = MemStore::new();
+        let kv = MemStore::new();
+        async fn test(kv: &MemStore, name: &str, hash: Option<&str>) {
             let kvw = kv.write(LogContext::new()).await.unwrap();
-            let mut w = Write { kvw };
+            let mut w = Write::new(kvw);
             w.set_head(name, hash).await.unwrap();
             match hash {
                 Some(h) => assert_eq!(
@@ -102,46 +256,85 @@ mod tests {
                 ),
                 None => assert!(w.kvw.get(&format!("h/{}", name)).await.unwrap().is_none()),
             }
+            w.commit().await.unwrap();
         }
 
-        test("", Some("")).await;
-        test("", Some("h1")).await;
-        test("n1", Some("")).await;
-        test("n1", Some("h1")).await;
-        test("n1", Some("h1")).await;
-        test("n1", None).await;
+        {
+            test(&kv, "", Some("")).await;
+            let kvr = kv.read(LogContext::new()).await.unwrap();
+            assert_ref_count(kvr.as_ref(), "", 1).await;
+        }
+        {
+            test(&kv, "", Some("h1")).await;
+            let kvr = kv.read(LogContext::new()).await.unwrap();
+            assert_ref_count(kvr.as_ref(), "h1", 1).await;
+            assert_ref_count(kvr.as_ref(), "", 0).await;
+        }
+        {
+            test(&kv, "n1", Some("")).await;
+            let kvr = kv.read(LogContext::new()).await.unwrap();
+            assert_ref_count(kvr.as_ref(), "", 1).await;
+        }
+        {
+            test(&kv, "n1", Some("h1")).await;
+            let kvr = kv.read(LogContext::new()).await.unwrap();
+            assert_ref_count(kvr.as_ref(), "h1", 2).await;
+            assert_ref_count(kvr.as_ref(), "", 0).await;
+        }
+        {
+            test(&kv, "n1", Some("h1")).await;
+            let kvr = kv.read(LogContext::new()).await.unwrap();
+            assert_ref_count(kvr.as_ref(), "h1", 2).await;
+            assert_ref_count(kvr.as_ref(), "", 0).await;
+        }
+        {
+            test(&kv, "n1", None).await;
+            let kvr = kv.read(LogContext::new()).await.unwrap();
+            assert_ref_count(kvr.as_ref(), "h1", 1).await;
+            assert_ref_count(kvr.as_ref(), "", 0).await;
+        }
+        {
+            test(&kv, "", None).await;
+            let kvr = kv.read(LogContext::new()).await.unwrap();
+            assert_ref_count(kvr.as_ref(), "h1", 0).await;
+            assert_ref_count(kvr.as_ref(), "", 0).await;
+        }
     }
 
     #[async_std::test]
     async fn commit_rollback() {
-        async fn test(commit: bool) {
+        async fn test(commit: bool, set_head: bool) {
             let key: String;
             let kv = MemStore::new();
             {
                 let kvw = kv.write(LogContext::new()).await.unwrap();
-                let mut w = Write { kvw };
+                let mut w = Write::new(kvw);
                 let c = Chunk::new((vec![0, 1], 0), &vec![]);
                 w.put_chunk(&c).await.unwrap();
 
-                key = format!("c/{}/d", c.hash());
+                key = Key::ChunkData(c.hash()).to_string();
 
                 // The changes should be present inside the tx.
                 assert!(w.kvw.has(&key).await.unwrap());
 
                 if commit {
+                    if set_head {
+                        w.set_head("test", Some(c.hash())).await.unwrap();
+                    }
                     w.commit().await.unwrap();
                 } else {
                     w.rollback().await.unwrap();
                 }
             }
 
-            // The data should now be visible if it was committed.
+            // The data shoul only persist if we set the head and commit.
             let kvr = kv.read(LogContext::new()).await.unwrap();
-            assert_eq!(commit, kvr.has(&key).await.unwrap());
+            assert_eq!(set_head && commit, kvr.has(&key).await.unwrap());
         }
 
-        test(true).await;
-        test(false).await;
+        test(true, false).await;
+        test(false, false).await;
+        test(true, true).await;
     }
 
     #[async_std::test]
@@ -151,7 +344,7 @@ mod tests {
             let c = Chunk::new((data.to_vec(), 0), refs);
             {
                 let kvw = kv.write(LogContext::new()).await.unwrap();
-                let mut w = Write { kvw };
+                let mut w = Write::new(kvw);
                 w.put_chunk(&c).await.unwrap();
                 w.set_head(name, Some(c.hash())).await.unwrap();
 

--- a/src/dag/write.rs
+++ b/src/dag/write.rs
@@ -155,7 +155,7 @@ impl<'a> Write<'_> {
     async fn set_ref_count(&self, hash: &str, count: u16) -> Result<()> {
         // Ref count is represented as a u16 stored as 2 bytes using BE.
         let ref_count_key = Key::ChunkRefCount(hash).to_string();
-        let buf = count.to_be_bytes();
+        let buf = count.to_le_bytes();
         if count == 0u16 {
             self.kvw.del(&ref_count_key).await?;
         } else {
@@ -168,7 +168,7 @@ impl<'a> Write<'_> {
         let buf = self.kvw.get(&Key::ChunkRefCount(hash).to_string()).await?;
         Ok(match buf {
             None => 0u16,
-            Some(buf) => u16::from_be_bytes(
+            Some(buf) => u16::from_le_bytes(
                 buf[..]
                     .try_into()
                     .map_err(|_e| Error::CorruptStore(str!("invalid ref count value")))?,

--- a/src/dag/write.rs
+++ b/src/dag/write.rs
@@ -350,7 +350,7 @@ mod tests {
                 }
             }
 
-            // The data shoul only persist if we set the head and commit.
+            // The data should only persist if we set the head and commit.
             let kvr = kv.read(LogContext::new()).await.unwrap();
             assert_eq!(set_head && commit, kvr.has(&key).await.unwrap());
         }

--- a/src/dag/write.rs
+++ b/src/dag/write.rs
@@ -249,7 +249,7 @@ mod tests {
             assert!(buf.is_none());
         } else {
             let buf = buf.unwrap();
-            let m_count = ((buf[0] as u16) << 8) + (buf[1] as u16);
+            let m_count = u16::from_le_bytes(buf[..].try_into().unwrap());
             assert_eq!(m_count, count);
         }
     }

--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -20,6 +20,7 @@ lazy_static! {
     static ref TRANSACTION_COUNTER: AtomicU32 = AtomicU32::new(1);
 }
 
+#[allow(clippy::large_enum_variant)]
 enum Transaction<'a> {
     Read(db::OwnedRead<'a>),
     Write(db::Write<'a>),

--- a/src/prolly/map.rs
+++ b/src/prolly/map.rs
@@ -437,6 +437,8 @@ mod tests {
             // Original map should still have same data.
             test(&map, &expected);
 
+            write.set_head("iter_flush", Some(&hash)).await.unwrap();
+
             // The hash should yield a new map with same data
             write.commit().await.unwrap();
             let read = store.read(LogContext::new()).await.unwrap();

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1022,9 +1022,6 @@ mod tests {
             for _ in 0..c.num_pending {
                 add_local(&mut chain, &store).await;
             }
-            if c.intervening_sync {
-                add_snapshot(&mut chain, &store, None).await;
-            }
             let mut dag_write = store.write(LogContext::new()).await.unwrap();
             dag_write
                 .set_head(
@@ -1044,6 +1041,10 @@ mod tests {
             .await
             .unwrap();
             let mut basis_hash = w.commit(SYNC_HEAD_NAME, "TODO local date").await.unwrap();
+
+            if c.intervening_sync {
+                add_snapshot(&mut chain, &store, None).await;
+            }
 
             for i in 0..c.num_pending - c.num_needing_replay {
                 let chain_index = i + 1; // chain[0] is genesis


### PR DESCRIPTION
We use ref counting to implement garbage collection. This is done at the
`dag::Write` layer. We do the garbage collection in `dag::Write::commit`.

- A head keeps a chunk alive.
- A ref from one alive chunk to another chunk keeps the other chunk
  alive.

When we call `set_head` we record the new and old hash so that we can
increment and decrement the ref counts later in `commit`.

When we call `put_chunk` we record the hash so that we can check for
orphaned chunks in `commit`.

Fixes #34