### PR TITLE
Parallelize set_head

### DIFF
--- a/src/dag/write.rs
+++ b/src/dag/write.rs
@@ -5,6 +5,7 @@ use crate::kv;
 use async_recursion::async_recursion;
 use async_std::sync::RwLock;
 use futures::future::try_join_all;
+use futures::future::TryFutureExt;
 use futures::try_join;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -63,31 +64,41 @@ impl<'a> Write<'_> {
         Ok(())
     }
 
-    pub async fn set_head(&mut self, name: &str, hash: Option<&str>) -> Result<()> {
+    pub async fn set_head(&self, name: &str, hash: Option<&str>) -> Result<()> {
         let old_hash = self.read().get_head(name).await?;
-
-        // TODO: These can be done in parallel.
-
         let head_key = Key::Head(name).to_string();
-        match hash {
-            None => self.kvw.del(&head_key).await?,
-            Some(h) => self.kvw.put(&head_key, h.as_bytes()).await?,
-        }
 
+        try_join!(
+            match hash {
+                None => self.kvw.del(&head_key),
+                Some(h) => self.kvw.put(&head_key, h.as_bytes()),
+            }
+            .map_err(Error::Storage),
+            self.update_change_heads(name, hash, old_hash)
+        )?;
+
+        Ok(())
+    }
+
+    async fn update_change_heads(
+        &self,
+        name: &str,
+        new_hash: Option<&str>,
+        old_hash: Option<String>,
+    ) -> Result<()> {
         let mut map = self.changed_heads.write().await;
         match map.entry(name.to_string()) {
             Entry::Occupied(mut entry) => {
                 // Keep old if occupied.
-                entry.get_mut().new = hash.map(str::to_string);
+                entry.get_mut().new = new_hash.map(str::to_string);
             }
             Entry::Vacant(entry) => {
                 entry.insert(HeadChange {
-                    new: hash.map(str::to_string),
+                    new: new_hash.map(str::to_string),
                     old: old_hash,
                 });
             }
         }
-
         Ok(())
     }
 
@@ -269,7 +280,7 @@ mod tests {
         let kv = MemStore::new();
         async fn test(kv: &MemStore, name: &str, hash: Option<&str>) {
             let kvw = kv.write(LogContext::new()).await.unwrap();
-            let mut w = Write::new(kvw);
+            let w = Write::new(kvw);
             w.set_head(name, hash).await.unwrap();
             match hash {
                 Some(h) => assert_eq!(

--- a/src/db/root.rs
+++ b/src/db/root.rs
@@ -41,7 +41,7 @@ mod tests {
             let kvs = MemStore::new();
             let ds = dag::Store::new(Box::from(kvs));
             if let Some(v) = head_val {
-                let mut dw = ds.write(LogContext::new()).await.unwrap();
+                let dw = ds.write(LogContext::new()).await.unwrap();
                 dw.set_head(db::DEFAULT_HEAD_NAME, Some(&v)).await.unwrap();
                 dw.commit().await.unwrap();
             }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -223,7 +223,7 @@ pub async fn maybe_end_sync(
     // TODO put sync_id in the logging context (lc.add_context()).
 
     // Ensure sync head is what the caller thinks it is.
-    let mut dag_write = store
+    let dag_write = store
         .write(lc.clone())
         .await
         .map_err(OpenWriteTxWriteError)?;
@@ -747,7 +747,7 @@ mod tests {
         for c in cases.iter() {
             // Reset state of the store.
             chain.truncate(2);
-            let mut w = store.write(LogContext::new()).await.unwrap();
+            let w = store.write(LogContext::new()).await.unwrap();
             w.set_head(
                 DEFAULT_HEAD_NAME,
                 Some(chain[chain.len() - 1].chunk().hash()),
@@ -1022,7 +1022,7 @@ mod tests {
             for _ in 0..c.num_pending {
                 add_local(&mut chain, &store).await;
             }
-            let mut dag_write = store.write(LogContext::new()).await.unwrap();
+            let dag_write = store.write(LogContext::new()).await.unwrap();
             dag_write
                 .set_head(
                     db::DEFAULT_HEAD_NAME,


### PR DESCRIPTION
We can do the idb write and the update of the changed_heads in parallel.