### PR TITLE
JSON patch compatible clear

### DIFF
--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -116,7 +116,7 @@ pub async fn begin_sync(
         client_id,
         base_state_id: base_state_id.clone(),
         checksum: base_checksum.clone(),
-        version: 1,
+        version: 2,
     };
     debug!(lc, "Starting pull...");
     let pull_timer = rlog::Timer::new().map_err(InternalTimerError)?;
@@ -493,9 +493,9 @@ mod tests {
             last_mutation_id: 10,
             patch: vec![
                 Operation {
-                    op: str!("remove"),
-                    path: str!("/"),
-                    value_string: str!(""),
+                    op: str!("replace"),
+                    path: str!(""),
+                    value_string: str!("{}"),
                 },
                 Operation {
                     op: str!("add"),
@@ -540,7 +540,7 @@ mod tests {
                     client_id: client_id.clone(),
                     base_state_id: base_server_state_id.clone(),
                     checksum: base_checksum.clone(),
-                    version: 1,
+                    version: 2,
                 },
                 pull_result: Ok(good_pull_resp.clone()),
                 exp_err: None,
@@ -577,7 +577,7 @@ mod tests {
                     client_id: client_id.clone(),
                     base_state_id: base_server_state_id.clone(),
                     checksum: base_checksum.clone(),
-                    version: 1,
+                    version: 2,
                 },
                 pull_result: Ok(good_pull_resp.clone()),
                 exp_err: None,
@@ -614,7 +614,7 @@ mod tests {
                     client_id: client_id.clone(),
                     base_state_id: base_server_state_id.clone(),
                     checksum: base_checksum.clone(),
-                    version: 1,
+                    version: 2,
                 },
                 pull_result: Ok(good_pull_resp.clone()),
                 exp_err: None,
@@ -639,7 +639,7 @@ mod tests {
                     client_id: client_id.clone(),
                     base_state_id: base_server_state_id.clone(),
                     checksum: base_checksum.clone(),
-                    version: 1,
+                    version: 2,
                 },
                 pull_result: Ok(PullResponse {
                     state_id: base_server_state_id.clone(),
@@ -661,7 +661,7 @@ mod tests {
                     client_id: client_id.clone(),
                     base_state_id: base_server_state_id.clone(),
                     checksum: base_checksum.clone(),
-                    version: 1,
+                    version: 2,
                 },
                 pull_result: Ok(PullResponse {
                     last_mutation_id: 0,
@@ -680,7 +680,7 @@ mod tests {
                     client_id: client_id.clone(),
                     base_state_id: base_server_state_id.clone(),
                     checksum: base_checksum.clone(),
-                    version: 1,
+                    version: 2,
                 },
                 pull_result: Ok(PullResponse {
                     state_id: str!(""),
@@ -699,7 +699,7 @@ mod tests {
                     client_id: client_id.clone(),
                     base_state_id: base_server_state_id.clone(),
                     checksum: base_checksum.clone(),
-                    version: 1,
+                    version: 2,
                 },
                 pull_result: Ok(PullResponse {
                     checksum: str!(""),
@@ -718,7 +718,7 @@ mod tests {
                     client_id: client_id.clone(),
                     base_state_id: base_server_state_id.clone(),
                     checksum: base_checksum.clone(),
-                    version: 1,
+                    version: 2,
                 },
                 pull_result: Ok(PullResponse {
                     checksum: str!(12345678),
@@ -737,7 +737,7 @@ mod tests {
                     client_id: client_id.clone(),
                     base_state_id: base_server_state_id.clone(),
                     checksum: base_checksum.clone(),
-                    version: 1,
+                    version: 2,
                 },
                 pull_result: Err(str!("FetchNotOk(500)")),
                 exp_err: Some("FetchNotOk(500)"),
@@ -1136,7 +1136,7 @@ mod tests {
                 client_id: str!("client_id"),
                 base_state_id: str!("base-state-id"),
                 checksum: str!("00000000"),
-                version: 1,
+                version: 2,
             };
             // EXP_BODY must be 'static to be used in HTTP handler closure.
             static ref EXP_BODY: String = serde_json::to_string(&*PULL_REQ).unwrap();
@@ -1156,15 +1156,15 @@ mod tests {
             Case {
                 name: "200",
                 resp_status: 200,
-                resp_body: r#"{"stateID": "1", "lastMutationID": 2, "checksum": "12345678", "patch": [{"op":"remove","path":"/"}], "clientViewInfo": { "httpStatusCode": 200, "errorMessage": "" }}"#,
+                resp_body: r#"{"stateID": "1", "lastMutationID": 2, "checksum": "12345678", "patch": [{"op":"replace","path":"","valueString":"{}"}], "clientViewInfo": { "httpStatusCode": 200, "errorMessage": "" }}"#,
                 exp_err: None,
                 exp_resp: Some(PullResponse {
                     state_id: str!("1"),
                     last_mutation_id: 2,
                     patch: vec![Operation {
-                        op: str!("remove"),
-                        path: str!("/"),
-                        value_string: str!(""),
+                        op: str!("replace"),
+                        path: str!(""),
+                        value_string: str!("{}"),
                     }],
                     checksum: str!("12345678"),
                     client_view_info: ClientViewInfo {

--- a/src/sync/patch.rs
+++ b/src/sync/patch.rs
@@ -18,6 +18,16 @@ pub struct Operation {
 pub fn apply(db_write: &mut db::Write, patch: &[Operation]) -> Result<(), PatchError> {
     use PatchError::*;
     for op in patch.iter() {
+        // Special case `{"op": "replace", "path": "", "value": {}}` which means
+        // replace the root with a new map, in other words, clear the map.
+        if op.path.is_empty() {
+            if op.op == OP_REPLACE && op.value_string == "{}" {
+                db_write.clear();
+                continue;
+            }
+            return Err(InvalidPath(op.path.clone()));
+        }
+
         let mut chars = op.path.chars();
         if chars.next() != Some('/') {
             return Err(InvalidPath(op.path.clone()));
@@ -31,12 +41,7 @@ pub fn apply(db_write: &mut db::Write, patch: &[Operation]) -> Result<(), PatchE
             }
             // Should we error if we try to remove a key that doesn't exist?
             OP_REMOVE => {
-                if key.is_empty() {
-                    // Top-level remove (path == "/").
-                    db_write.clear();
-                } else {
-                    db_write.del(key);
-                }
+                db_write.del(key);
             }
             _ => return Err(InvalidOp(op.op.to_string())),
         };
@@ -114,8 +119,36 @@ mod tests {
                 exp_checksum: None,
             },
             Case {
+                name: "insert empty key",
+                patch: vec![r#"{"op":"add","path":"/","valueString":"\"empty\""}"#],
+                exp_err: None,
+                exp_map: Some(map!("key" => "value", "" => "\"empty\"")),
+                exp_checksum: None,
+            },
+            Case {
+                name: "insert/replace empty key",
+                patch: vec![
+                    r#"{"op":"add","path":"/","valueString":"\"empty\""}"#,
+                    r#"{"op":"replace","path":"/","valueString":"\"changed\""}"#,
+                ],
+                exp_err: None,
+                exp_map: Some(map!("key" => "value", "" => "\"changed\"")),
+                exp_checksum: None,
+            },
+            Case {
+                name: "insert/remove empty key",
+                patch: vec![
+                    r#"{"op":"add","path":"/","valueString":"\"empty\""}"#,
+                    r#"{"op":"remove","path":"/"}"#,
+                ],
+                exp_err: None,
+                exp_map: Some(map!("key" => "value")),
+                exp_checksum: None,
+            },
+            // Remove once all the other layers no longer depend on this.
+            Case {
                 name: "top-level remove",
-                patch: vec![r#"{"op":"remove","path":"/"}"#],
+                patch: vec![r#"{"op":"replace","path":"","valueString":"{}"}"#],
                 exp_err: None,
                 exp_map: Some(HashMap::new()),
                 exp_checksum: Some("00000000"),
@@ -164,7 +197,7 @@ mod tests {
             Case {
                 name: "known checksum",
                 patch: vec![
-                    r#"{"op":"remove","path":"/"}"#,
+                    r#"{"op":"replace","path":"","valueString":"{}"}"#,
                     r#"{"op":"add","path":"/new","valueString":"\"value\""}"#,
                 ],
                 exp_err: None,

--- a/src/sync/patch.rs
+++ b/src/sync/patch.rs
@@ -18,8 +18,9 @@ pub struct Operation {
 pub fn apply(db_write: &mut db::Write, patch: &[Operation]) -> Result<(), PatchError> {
     use PatchError::*;
     for op in patch.iter() {
-        // Special case `{"op": "replace", "path": "", "value": {}}` which means
-        // replace the root with a new map, in other words, clear the map.
+        // Special case `{"op": "replace", "path": "", "valueString": "{}"}`
+        // which means replace the root with a new map, in other words, clear
+        // the map.
         if op.path.is_empty() {
             if op.op == OP_REPLACE && op.value_string == "{}" {
                 db_write.clear();


### PR DESCRIPTION
This adds special code for dealing with
`{"op":"replace","path":"","value":{}}` which is what we use to clear
the map.

We still treat `{"op":"remove","path":"/"}` as clear for now but we
should update the other layers to not use that.

Towards #124