### PR TITLE
Stop depending on window()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,9 +1928,11 @@ name = "wasm-bench"
 version = "0.1.0"
 dependencies = [
  "async-fn",
+ "js-sys",
  "log",
  "thousands",
  "wasm-bench-macro",
+ "wasm-bindgen",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,6 @@ features = [
     "RequestInit",
     "RequestMode",
     "Response",
-    
-    # Do not add Window since we want repc to work in a Worker.
-    # "Window",
 ]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,9 @@ features = [
     "RequestInit",
     "RequestMode",
     "Response",
-    "Window",
+    
+    # Do not add Window since we want repc to work in a Worker.
+    # "Window",
 ]
 
 [lib]

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -10,6 +10,8 @@ log = "0.4"
 thousands = "0.2.0"
 wasm-bench-macro = { path = "../bench-macro" }
 web-sys = "0.3.42"
+js-sys = "0.3.40"
+wasm-bindgen = "0.2"
 
 [lib]
 test = false

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 
 [dependencies]
 async-fn = { path = "../async-fn" }
+js-sys = "0.3.40"
 log = "0.4"
 thousands = "0.2.0"
 wasm-bench-macro = { path = "../bench-macro" }
-web-sys = "0.3.42"
-js-sys = "0.3.40"
 wasm-bindgen = "0.2"
+web-sys = "0.3.42"
 
 [lib]
 test = false

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -1,15 +1,24 @@
 use async_fn::AsyncFn1;
+use js_sys::Reflect;
 use log::error;
 use std::cmp;
 use thousands::Separable;
 pub use wasm_bench_macro::wasm_bench;
+use wasm_bindgen::JsValue;
+use web_sys::Performance;
+
+pub fn performance() -> Performance {
+    use wasm_bindgen::JsCast;
+    let global = js_sys::global();
+    let key = JsValue::from_str("performance");
+    Reflect::get(&global, &key)
+        .expect("could not get performance")
+        .dyn_into()
+        .expect("invalid performance")
+}
 
 fn now_nanos() -> u64 {
-    let window = web_sys::window().expect("should have a window in this context");
-    let performance = window
-        .performance()
-        .expect("performance should be available");
-    return (performance.now() * 1e6) as u64;
+    return (performance().now() * 1e6) as u64;
 }
 
 pub struct Bench {

--- a/src/benches/mod.rs
+++ b/src/benches/mod.rs
@@ -22,13 +22,10 @@ fn random_string(len: usize) -> String {
 
 #[wasm_bench]
 async fn performance_now(b: &mut Bench) {
-    let window = web_sys::window().expect("should have a window in this context");
-    let performance = window
-        .performance()
-        .expect("performance should be available");
+    let p = performance();
 
     let n = b.iterations();
     for _ in 0..n {
-        || -> u64 { (performance.now() * 1e6) as u64 }();
+        || -> u64 { (p.now() * 1e6) as u64 }();
     }
 }

--- a/src/fetch/browser_client.rs
+++ b/src/fetch/browser_client.rs
@@ -2,6 +2,7 @@ use crate::fetch::errors::FetchError;
 use crate::fetch::errors::FetchError::*;
 use crate::fetch::timeout::with_timeout;
 use crate::util::to_debug;
+use js_sys::{Function, Promise, Reflect};
 use std::convert::TryFrom;
 use std::time::Duration;
 use wasm_bindgen::JsCast;
@@ -80,14 +81,11 @@ impl Client {
             .map_err(|e| UnableToSetRequestHeader(to_debug(e)))?;
         }
 
-        let window = web_sys::window().ok_or_else(|| NoWindow)?;
-        let http_req_promise = window.fetch_with_request(&web_sys_req);
+        let http_req_promise = fetch_with_request(&web_sys_req)?;
         let http_req_future = JsFuture::from(http_req_promise);
         let js_web_sys_resp = http_req_future.await.map_err(|e| RequestFailed(js(e)))?;
-        if !js_web_sys_resp.is_instance_of::<web_sys::Response>() {
-            return Err(InvalidResponseFromJS);
-        }
-        let web_sys_resp: web_sys::Response = js_web_sys_resp.dyn_into().unwrap();
+        let web_sys_resp: web_sys::Response =
+            js_web_sys_resp.dyn_into().map_err(InvalidResponseFromJs)?;
         let body_js_value = JsFuture::from(
             web_sys_resp
                 .text()
@@ -106,4 +104,17 @@ impl Client {
             .map_err(|e| FailedToWrapHttpResponse(to_debug(e)))?;
         Ok(http_resp)
     }
+}
+
+/// Like window().fetch_with_request but works in workers and main thread.
+fn fetch_with_request(req: &web_sys::Request) -> Result<Promise, FetchError> {
+    use FetchError::*;
+
+    let global = js_sys::global();
+    let key = JsValue::from_str("fetch");
+    let js_fetch: Function = Reflect::get(&global, &key)?.dyn_into()?;
+    js_fetch
+        .call1(&JsValue::undefined(), req)?
+        .dyn_into()
+        .map_err(InvalidResponseFromJs)
 }

--- a/src/fetch/browser_client.rs
+++ b/src/fetch/browser_client.rs
@@ -112,9 +112,13 @@ fn fetch_with_request(req: &web_sys::Request) -> Result<Promise, FetchError> {
 
     let global = js_sys::global();
     let key = JsValue::from_str("fetch");
-    let js_fetch: Function = Reflect::get(&global, &key)?.dyn_into()?;
-    js_fetch
-        .call1(&JsValue::undefined(), req)?
+    let js_fetch: Function = Reflect::get(&global, &key)
+        .map_err(NoFetch)?
         .dyn_into()
-        .map_err(InvalidResponseFromJs)
+        .map_err(NoFetch)?;
+    js_fetch
+        .call1(&JsValue::undefined(), req)
+        .map_err(FetchFailed)?
+        .dyn_into()
+        .map_err(FetchFailed)
 }

--- a/src/fetch/errors.rs
+++ b/src/fetch/errors.rs
@@ -5,20 +5,16 @@ use wasm_bindgen::JsValue;
 // FetchError is lossy of the error types underneath: it holds an error string.
 #[derive(Debug)]
 pub enum FetchError {
-    ErrorReadingResponseBodyAsString(String),
     ErrorReadingResponseBody(String),
+    ErrorReadingResponseBodyAsString(String),
     FailedToWrapHttpResponse(String),
+    FetchFailed(JsValue),
     InvalidRequestBody(String),
     InvalidRequestHeader(String),
     InvalidResponseFromJs(JsValue),
+    NoFetch(JsValue),
     RequestFailed(String),
     RequestTimeout(async_std::future::TimeoutError),
     UnableToCreateRequest(String),
     UnableToSetRequestHeader(String),
-}
-
-impl From<JsValue> for FetchError {
-    fn from(err: JsValue) -> FetchError {
-        FetchError::InvalidResponseFromJs(err)
-    }
 }

--- a/src/fetch/errors.rs
+++ b/src/fetch/errors.rs
@@ -1,3 +1,5 @@
+use wasm_bindgen::JsValue;
+
 // FetchErrors are returned by both the rust and browser versions of fetch. Since
 // lower level errors in each case will be coming from two different places,
 // FetchError is lossy of the error types underneath: it holds an error string.
@@ -8,10 +10,15 @@ pub enum FetchError {
     FailedToWrapHttpResponse(String),
     InvalidRequestBody(String),
     InvalidRequestHeader(String),
-    InvalidResponseFromJS,
-    NoWindow,
+    InvalidResponseFromJs(JsValue),
     RequestFailed(String),
     RequestTimeout(async_std::future::TimeoutError),
     UnableToCreateRequest(String),
     UnableToSetRequestHeader(String),
+}
+
+impl From<JsValue> for FetchError {
+    fn from(err: JsValue) -> FetchError {
+        FetchError::InvalidResponseFromJs(err)
+    }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -2,5 +2,6 @@
 pub mod rlog;
 mod to_debug;
 pub mod uuid;
+pub mod wasm;
 
 pub use to_debug::to_debug;

--- a/src/util/rlog/browser_timer.rs
+++ b/src/util/rlog/browser_timer.rs
@@ -1,4 +1,5 @@
 extern crate web_sys;
+use super::super::wasm::global_property;
 use super::errors::TimerError;
 
 pub struct Timer {
@@ -25,9 +26,5 @@ impl Timer {
 
 fn get_performance() -> Result<web_sys::Performance, TimerError> {
     use TimerError::*;
-    let performance = web_sys::window()
-        .ok_or(NoWindow)?
-        .performance()
-        .ok_or(NoPerformanceTimer)?;
-    Ok(performance)
+    global_property("performance").map_err(|_| NoPerformanceTimer)
 }

--- a/src/util/uuid/mod.rs
+++ b/src/util/uuid/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(target_arch = "wasm32")]
+use super::wasm::global_property;
 use std::char;
 use wasm_bindgen::prelude::*;
 
@@ -10,12 +12,10 @@ pub fn uuid() -> String {
 
 #[cfg(target_arch = "wasm32")]
 fn make_random_numbers(numbers: &mut [u8]) {
-    web_sys::window()
-        .expect("window is not available")
-        .crypto()
-        .expect("window.crypto is not available")
+    global_property::<web_sys::Crypto>("crypto")
+        .expect("crypto is not available")
         .get_random_values_with_u8_array(numbers)
-        .expect("window.crypto.getRandomValues not available");
+        .expect("crypto.getRandomValues not available");
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/util/uuid/mod.rs
+++ b/src/util/uuid/mod.rs
@@ -12,6 +12,7 @@ pub fn uuid() -> String {
 
 #[cfg(target_arch = "wasm32")]
 fn make_random_numbers(numbers: &mut [u8]) {
+    // TODO(arv): Return result instead of crashing.
     global_property::<web_sys::Crypto>("crypto")
         .expect("crypto is not available")
         .get_random_values_with_u8_array(numbers)

--- a/src/util/wasm/mod.rs
+++ b/src/util/wasm/mod.rs
@@ -1,0 +1,10 @@
+use wasm_bindgen::{JsCast, JsValue};
+
+pub fn global_property<T>(property: &str) -> Result<T, JsValue>
+where
+    T: wasm_bindgen::JsCast,
+{
+    let global = js_sys::global();
+    let key = JsValue::from_str(property);
+    js_sys::Reflect::get(&global, &key)?.dyn_into()
+}

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -2,7 +2,6 @@
 
 use futures::join;
 use rand::Rng;
-use replicache_client::embed::types::*;
 #[allow(unused_imports)]
 use replicache_client::fetch;
 #[allow(unused_imports)]
@@ -10,6 +9,7 @@ use replicache_client::sync;
 use replicache_client::util::rlog;
 use replicache_client::util::to_debug;
 use replicache_client::wasm;
+use replicache_client::{embed::types::*, util::wasm::global_property};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::json;
@@ -211,9 +211,7 @@ async fn test_open_close() {
 #[wasm_bindgen_test]
 async fn test_dispatch_concurrency() {
     let db = &random_db();
-    let window = web_sys::window().expect("should have a window in this context");
-    let performance = window
-        .performance()
+    let performance = global_property::<web_sys::Performance>("performance")
         .expect("performance should be available");
 
     assert_eq!(dispatch::<_, String>(db, "open", "").await.unwrap(), "");


### PR DESCRIPTION
Workers do not have a window.

The new preferred way is to use `global_property("indexedDB")` instead
which gets the property of the global object, no matter if that is
`window`, `self`, `globalThis` etc.

Fixes #228