### PR TITLE
db.write.clear() also clears indexes

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -19,5 +19,6 @@ pub use commit::{
 pub use read::{read_commit, read_indexes, OwnedRead, Read, ReadCommitError, ScanError, Whence};
 pub use scan::{ScanBound, ScanKey, ScanOptions};
 pub use write::{
-    init_db, CommitError, CreateIndexError, DelError, DropIndexError, InitDBError, PutError, Write,
+    init_db, ClearError, CommitError, CreateIndexError, DelError, DropIndexError, InitDBError,
+    PutError, Write,
 };

--- a/src/sync/patch.rs
+++ b/src/sync/patch.rs
@@ -23,7 +23,7 @@ pub async fn apply(db_write: &mut db::Write<'_>, patch: &[Operation]) -> Result<
         // the map.
         if op.path.is_empty() {
             if op.op == OP_REPLACE && op.value_string == "{}" {
-                db_write.clear();
+                db_write.clear().await.map_err(ClearError)?;
                 continue;
             }
             return Err(InvalidPath(op.path.clone()));
@@ -56,10 +56,11 @@ fn json_pointer_unescape(s: &str) -> String {
 
 #[derive(Debug)]
 pub enum PatchError {
+    ClearError(db::ClearError),
+    DelError(db::DelError),
     InvalidOp(String),
     InvalidPath(String),
     PutError(db::PutError),
-    DelError(db::DelError),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This change was almost entirely authored by @aboodman , just merging it for him.

My code review: LGTM

Progress towards #218 