### PR TITLE
start simplifying index code and make exclusive work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,17 +334,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
-name = "bytekey-fix"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04c6e4e359c9777e3ff6697b84d5a1f233aa5aa7759c36044c095698417e144"
-dependencies = [
- "byteorder",
- "serde",
- "utf-8",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,7 +1279,6 @@ dependencies = [
  "async-recursion",
  "async-std",
  "async-trait",
- "bytekey-fix",
  "bytes",
  "console_error_panic_hook",
  "console_log",
@@ -1882,12 +1870,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ async-fn = { path = "crates/async-fn" }
 async-recursion = "0.3.1"
 async-std = { version = "=1.6.0", features = ["unstable"] }
 async-trait = "0.1.36"
-bytekey = { package = "bytekey-fix", version = "0.5.0"}
 console_log = { version = "0.2" }
 console_error_panic_hook = { version = "0.1.1", optional = true }
 crc = "1.8.1"

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -16,7 +16,7 @@ pub use commit::{
     BaseSnapshotError, Commit, FromHashError, InternalProgrammerError, LocalMeta, MetaTyped,
     PendingError, DEFAULT_HEAD_NAME,
 };
-pub use index::{index_key, GetIndexKeysError, IndexValue};
+pub use index::{encode_index_key, encode_scan_key, GetIndexKeysError};
 pub use read::{read_commit, read_indexes, OwnedRead, Read, ReadCommitError, ScanError, Whence};
 pub use scan::{ScanBound, ScanKey, ScanOptions};
 pub use write::{

--- a/src/db/read.rs
+++ b/src/db/read.rs
@@ -150,7 +150,7 @@ impl<'a> Read<'a> {
             // prefix
             if opts.prefix.is_some() {
                 prefix = Some(
-                    index::encode_scan_key(opts.prefix.as_ref().unwrap())
+                    index::encode_scan_key(opts.prefix.as_ref().unwrap(), false)
                         .map_err(ScanError::ParseScanOptionsError)?,
                 );
                 opts_internal.prefix = Some(prefix.as_ref().unwrap());
@@ -161,9 +161,15 @@ impl<'a> Read<'a> {
                 .start
                 .as_ref()
                 .and_then(|sb| sb.key.as_ref().map(|sk| &sk.value));
+            let scan_key_exclusive = opts
+                .start
+                .as_ref()
+                .and_then(|sb| sb.key.as_ref().map(|sk| sk.exclusive))
+                .unwrap_or(false);
+
             if scan_key_value_string.is_some() {
                 scan_key_value = Some(
-                    index::encode_scan_key(scan_key_value_string.unwrap())
+                    index::encode_scan_key(scan_key_value_string.unwrap(), scan_key_exclusive)
                         .map_err(ScanError::ParseScanOptionsError)?,
                 );
 

--- a/src/db/read.rs
+++ b/src/db/read.rs
@@ -150,7 +150,7 @@ impl<'a> Read<'a> {
             // prefix
             if opts.prefix.is_some() {
                 prefix = Some(
-                    index::scan_key(opts.prefix.as_ref().unwrap())
+                    index::encode_scan_key(opts.prefix.as_ref().unwrap())
                         .map_err(ScanError::ParseScanOptionsError)?,
                 );
                 opts_internal.prefix = Some(prefix.as_ref().unwrap());
@@ -163,7 +163,7 @@ impl<'a> Read<'a> {
                 .and_then(|sb| sb.key.as_ref().map(|sk| &sk.value));
             if scan_key_value_string.is_some() {
                 scan_key_value = Some(
-                    index::index_key(index::IndexValue::Str(scan_key_value_string.unwrap()), &[])
+                    index::encode_scan_key(scan_key_value_string.unwrap())
                         .map_err(ScanError::ParseScanOptionsError)?,
                 );
 

--- a/src/db/read.rs
+++ b/src/db/read.rs
@@ -170,10 +170,7 @@ impl<'a> Read<'a> {
                 let start = opts_internal.start.unwrap();
                 let mut key = start.key.unwrap();
                 key.value = scan_key_value.as_ref().unwrap();
-                opts_internal.start = Some(super::scan::ScanBoundInternal {
-                    key: Some(key),
-                    index: start.index,
-                });
+                opts_internal.start = Some(super::scan::ScanBoundInternal { key: Some(key) });
             }
         }
 

--- a/src/db/write.rs
+++ b/src/db/write.rs
@@ -635,10 +635,10 @@ mod tests {
             for i in 0..3 {
                 assert_eq!(
                     entries.get(i).unwrap().key,
-                    bytekey::serialize(&index::IndexKeyType::V0(index::IndexKey {
-                        secondary: index::IndexValue::Str(format!("s{}", i).as_str()),
+                    index::encode_index_key(&index::IndexKey {
+                        secondary: format!("s{}", i).as_str(),
                         primary: format!("k{}", i).as_bytes(),
-                    }))
+                    })
                     .unwrap()
                     .as_slice()
                 );


### PR DESCRIPTION
separate logic commits:
- make exclusive work
- remove scan key index (offset)
- encode index keys ourselves and simplify IndexKey

TODO:
- eliminate ScanOptionsInternal and friends
- flatten ScanOptions for convenience

This feels a lot better to me than what we had before. @arv this changes the interface but i would wait for me to land next set of changes before doing the work to switch over. I'm going to simplify ScanOptions a bit.

Progress towards #250 