### PR TITLE
simplify ScanOptions

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -18,7 +18,7 @@ pub use commit::{
 };
 pub use index::{encode_index_key, encode_scan_key, GetIndexKeysError};
 pub use read::{read_commit, read_indexes, OwnedRead, Read, ReadCommitError, ScanError, Whence};
-pub use scan::{ScanBound, ScanKey, ScanOptions};
+pub use scan::ScanOptions;
 pub use write::{
     init_db, ClearError, CommitError, CreateIndexError, DelError, DropIndexError, InitDBError,
     PutError, Write,

--- a/src/db/write.rs
+++ b/src/db/write.rs
@@ -239,9 +239,10 @@ impl<'a> Write<'a> {
         for entry in scan::scan(
             &self.map,
             scan::ScanOptionsInternal {
-                prefix: key_prefix.into(),
+                prefix: Some(key_prefix.into()),
                 limit: None,
-                start: None,
+                start_key: None,
+                start_key_exclusive: None,
                 index_name: None,
             },
         ) {

--- a/src/embed/types.rs
+++ b/src/embed/types.rs
@@ -111,17 +111,15 @@ pub struct ScanRequest {
     #[serde(skip)]
     pub receiver: Option<js_sys::Function>,
 }
-
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
-pub struct ScanResponse {}
-
 #[derive(Debug)]
 pub enum ScanError {
     MissingReceiver,
     InvalidReceiver,
-    ParseScanOptionsError(db::GetIndexKeysError),
     ScanError(db::ScanError),
 }
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+pub struct ScanResponse {}
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PutRequest {

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -2,7 +2,7 @@
 
 use futures::join;
 use rand::Rng;
-use replicache_client::db::{ScanBound, ScanKey, ScanOptions};
+use replicache_client::db::ScanOptions;
 #[allow(unused_imports)]
 use replicache_client::fetch;
 use replicache_client::sync;
@@ -140,12 +140,8 @@ async fn scan(
             transaction_id: txn_id,
             opts: ScanOptions {
                 prefix: Some(prefix.to_string()),
-                start: Some(ScanBound {
-                    key: Some(ScanKey {
-                        value: start_key.to_string(),
-                        exclusive,
-                    }),
-                }),
+                start_key: Some(start_key.to_string()),
+                start_key_exclusive: Some(exclusive),
                 limit: None,
                 index_name: index_name.map(|s| s.into()),
             },
@@ -472,7 +468,8 @@ async fn test_create_drop_index() {
                 transaction_id,
                 opts: ScanOptions {
                     prefix: None,
-                    start: None,
+                    start_key: None,
+                    start_key_exclusive: None,
                     limit: None,
                     index_name: Some(str!("idx1")),
                 },


### PR DESCRIPTION
major improvement in my mind:
- flatten ScanOptions
- make ScanOptions own its fields
- hide scan key generation in TryFrom
- delete a mess of glue cruft that the previous complexity necessitated
- interface to scan::scan() stays bytes

@arv this has breaking changes for js

Progress towards #218 