### PR TITLE
index arrays of strings

### DIFF
--- a/src/db/read.rs
+++ b/src/db/read.rs
@@ -168,9 +168,13 @@ mod tests {
         )
         .await
         .unwrap();
-        w.put("foo".as_bytes().to_vec(), "bar".as_bytes().to_vec())
-            .await
-            .unwrap();
+        w.put(
+            LogContext::new(),
+            "foo".as_bytes().to_vec(),
+            "bar".as_bytes().to_vec(),
+        )
+        .await
+        .unwrap();
         w.commit(db::DEFAULT_HEAD_NAME).await.unwrap();
 
         let dr = ds.read(LogContext::new()).await.unwrap();

--- a/src/db/test_helpers.rs
+++ b/src/db/test_helpers.rs
@@ -40,9 +40,13 @@ pub async fn add_local<'a>(chain: &'a mut Chain, store: &dag::Store) -> &'a mut 
     )
     .await
     .unwrap();
-    w.put(vec![4, 2], format!("{}", chain.len()).into_bytes())
-        .await
-        .unwrap();
+    w.put(
+        LogContext::new(),
+        vec![4, 2],
+        format!("{}", chain.len()).into_bytes(),
+    )
+    .await
+    .unwrap();
     w.commit(db::DEFAULT_HEAD_NAME).await.unwrap();
     let (_, commit, _) = read_commit(
         Whence::Head(str!(db::DEFAULT_HEAD_NAME)),
@@ -81,9 +85,13 @@ pub async fn add_snapshot<'a>(
     if let Some(m) = map {
         let mut i = 0;
         while i <= m.len() - 2 {
-            w.put(m[i].as_bytes().into(), m[i + 1].as_bytes().into())
-                .await
-                .unwrap();
+            w.put(
+                LogContext::new(),
+                m[i].as_bytes().into(),
+                m[i + 1].as_bytes().into(),
+            )
+            .await
+            .unwrap();
             i += 2;
         }
     }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -738,8 +738,8 @@ async fn test_scan_with_index() {
     }
 
     // Test the various levers of the scan interface when used with an index...
-    // Scan all indexed values
     for in_txn in bools.iter() {
+        // Scan all indexed values
         test(
             vec![("key", r#""value""#)],
             "",
@@ -750,6 +750,22 @@ async fn test_scan_with_index() {
             "",
             false,
             vec![("key", Some("value"), r#""value""#)],
+        )
+        .await;
+        // Scan an indexed array
+        test(
+            vec![("key", r#"{"s": ["value1", "value2"]}"#)],
+            "",
+            "/s",
+            Op::None,
+            *in_txn,
+            "",
+            "",
+            false,
+            vec![
+                ("key", Some("value1"), r#"{"s": ["value1", "value2"]}"#),
+                ("key", Some("value2"), r#"{"s": ["value1", "value2"]}"#),
+            ],
         )
         .await;
         // indexes is on key prefix that is not present


### PR DESCRIPTION
also make error handling a little more consistent: refuse to index a value if there are any problems

progress towards #218 

closes https://github.com/rocicorp/repc/issues/230