### PR TITLE
make a separate transaction type for index changes

### DIFF
--- a/src/db/commit.fbs
+++ b/src/db/commit.fbs
@@ -1,3 +1,5 @@
+// Note: use tool/flatc.sh to generate the .rs file from this definition.
+
 // This file describes the Commit struct used to track changes to a Replicache
 // instance.
 namespace commit;
@@ -36,7 +38,7 @@ table IndexDefinition {
     json_pointer: string;
 }
 
-table Index {
+table IndexRecord {
     definition: IndexDefinition;
     value_hash: string;  // root hash of prolly::Map for index
 }
@@ -49,7 +51,7 @@ table Commit {
     // Vector of current indexes.
     // Invariant: index names are unique
     // Invariant: indexes are always up to date with data in value_hash
-    indexes: [Index];
+    indexes: [IndexRecord];
 }
 
 root_type Commit;

--- a/src/db/commit.fbs
+++ b/src/db/commit.fbs
@@ -4,6 +4,13 @@
 // instance.
 namespace commit;
 
+// Commit metadata specific to index change commits.
+table IndexChangeMeta {
+    last_mutation_id: ulong;
+    // We could keep track of new and dropped index definitions here
+    // if we wanted to, but there is little value in it atm.
+}
+
 // Commit metadata specific to local commits.
 table LocalMeta {
     mutation_id: ulong;
@@ -20,6 +27,7 @@ table SnapshotMeta {
 
 // Commit metadata specific to the type of commit.
 union MetaTyped {
+    IndexChangeMeta,
     LocalMeta,
     SnapshotMeta,
 }

--- a/src/db/commit_generated.rs
+++ b/src/db/commit_generated.rs
@@ -582,15 +582,15 @@ pub mod commit {
         }
     }
 
-    pub enum IndexOffset {}
+    pub enum IndexRecordOffset {}
     #[derive(Copy, Clone, Debug, PartialEq)]
 
-    pub struct Index<'a> {
+    pub struct IndexRecord<'a> {
         pub _tab: flatbuffers::Table<'a>,
     }
 
-    impl<'a> flatbuffers::Follow<'a> for Index<'a> {
-        type Inner = Index<'a>;
+    impl<'a> flatbuffers::Follow<'a> for IndexRecord<'a> {
+        type Inner = IndexRecord<'a>;
         #[inline]
         fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
             Self {
@@ -599,17 +599,17 @@ pub mod commit {
         }
     }
 
-    impl<'a> Index<'a> {
+    impl<'a> IndexRecord<'a> {
         #[inline]
         pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-            Index { _tab: table }
+            IndexRecord { _tab: table }
         }
         #[allow(unused_mut)]
         pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
             _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-            args: &'args IndexArgs<'args>,
-        ) -> flatbuffers::WIPOffset<Index<'bldr>> {
-            let mut builder = IndexBuilder::new(_fbb);
+            args: &'args IndexRecordArgs<'args>,
+        ) -> flatbuffers::WIPOffset<IndexRecord<'bldr>> {
+            let mut builder = IndexRecordBuilder::new(_fbb);
             if let Some(x) = args.value_hash {
                 builder.add_value_hash(x);
             }
@@ -626,58 +626,60 @@ pub mod commit {
         pub fn definition(&self) -> Option<IndexDefinition<'a>> {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<IndexDefinition<'a>>>(
-                    Index::VT_DEFINITION,
+                    IndexRecord::VT_DEFINITION,
                     None,
                 )
         }
         #[inline]
         pub fn value_hash(&self) -> Option<&'a str> {
             self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(Index::VT_VALUE_HASH, None)
+                .get::<flatbuffers::ForwardsUOffset<&str>>(IndexRecord::VT_VALUE_HASH, None)
         }
     }
 
-    pub struct IndexArgs<'a> {
+    pub struct IndexRecordArgs<'a> {
         pub definition: Option<flatbuffers::WIPOffset<IndexDefinition<'a>>>,
         pub value_hash: Option<flatbuffers::WIPOffset<&'a str>>,
     }
-    impl<'a> Default for IndexArgs<'a> {
+    impl<'a> Default for IndexRecordArgs<'a> {
         #[inline]
         fn default() -> Self {
-            IndexArgs {
+            IndexRecordArgs {
                 definition: None,
                 value_hash: None,
             }
         }
     }
-    pub struct IndexBuilder<'a: 'b, 'b> {
+    pub struct IndexRecordBuilder<'a: 'b, 'b> {
         fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
         start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
     }
-    impl<'a: 'b, 'b> IndexBuilder<'a, 'b> {
+    impl<'a: 'b, 'b> IndexRecordBuilder<'a, 'b> {
         #[inline]
         pub fn add_definition(&mut self, definition: flatbuffers::WIPOffset<IndexDefinition<'b>>) {
             self.fbb_
                 .push_slot_always::<flatbuffers::WIPOffset<IndexDefinition>>(
-                    Index::VT_DEFINITION,
+                    IndexRecord::VT_DEFINITION,
                     definition,
                 );
         }
         #[inline]
         pub fn add_value_hash(&mut self, value_hash: flatbuffers::WIPOffset<&'b str>) {
-            self.fbb_
-                .push_slot_always::<flatbuffers::WIPOffset<_>>(Index::VT_VALUE_HASH, value_hash);
+            self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+                IndexRecord::VT_VALUE_HASH,
+                value_hash,
+            );
         }
         #[inline]
-        pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> IndexBuilder<'a, 'b> {
+        pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> IndexRecordBuilder<'a, 'b> {
             let start = _fbb.start_table();
-            IndexBuilder {
+            IndexRecordBuilder {
                 fbb_: _fbb,
                 start_: start,
             }
         }
         #[inline]
-        pub fn finish(self) -> flatbuffers::WIPOffset<Index<'a>> {
+        pub fn finish(self) -> flatbuffers::WIPOffset<IndexRecord<'a>> {
             let o = self.fbb_.end_table(self.start_);
             flatbuffers::WIPOffset::new(o.value())
         }
@@ -740,9 +742,10 @@ pub mod commit {
         #[inline]
         pub fn indexes(
             &self,
-        ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Index<'a>>>> {
+        ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<IndexRecord<'a>>>>
+        {
             self._tab.get::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<flatbuffers::ForwardsUOffset<Index<'a>>>,
+                flatbuffers::Vector<flatbuffers::ForwardsUOffset<IndexRecord<'a>>>,
             >>(Commit::VT_INDEXES, None)
         }
     }
@@ -752,7 +755,7 @@ pub mod commit {
         pub value_hash: Option<flatbuffers::WIPOffset<&'a str>>,
         pub indexes: Option<
             flatbuffers::WIPOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Index<'a>>>,
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<IndexRecord<'a>>>,
             >,
         >,
     }
@@ -785,7 +788,7 @@ pub mod commit {
         pub fn add_indexes(
             &mut self,
             indexes: flatbuffers::WIPOffset<
-                flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Index<'b>>>,
+                flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<IndexRecord<'b>>>,
             >,
         ) {
             self.fbb_

--- a/src/db/commit_generated.rs
+++ b/src/db/commit_generated.rs
@@ -22,12 +22,13 @@ pub mod commit {
     #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
     pub enum MetaTyped {
         NONE = 0,
-        LocalMeta = 1,
-        SnapshotMeta = 2,
+        IndexChangeMeta = 1,
+        LocalMeta = 2,
+        SnapshotMeta = 3,
     }
 
     pub const ENUM_MIN_META_TYPED: u8 = 0;
-    pub const ENUM_MAX_META_TYPED: u8 = 2;
+    pub const ENUM_MAX_META_TYPED: u8 = 3;
 
     impl<'a> flatbuffers::Follow<'a> for MetaTyped {
         type Inner = Self;
@@ -61,14 +62,16 @@ pub mod commit {
     }
 
     #[allow(non_camel_case_types)]
-    pub const ENUM_VALUES_META_TYPED: [MetaTyped; 3] = [
+    pub const ENUM_VALUES_META_TYPED: [MetaTyped; 4] = [
         MetaTyped::NONE,
+        MetaTyped::IndexChangeMeta,
         MetaTyped::LocalMeta,
         MetaTyped::SnapshotMeta,
     ];
 
     #[allow(non_camel_case_types)]
-    pub const ENUM_NAMES_META_TYPED: [&'static str; 3] = ["NONE", "LocalMeta", "SnapshotMeta"];
+    pub const ENUM_NAMES_META_TYPED: [&'static str; 4] =
+        ["NONE", "IndexChangeMeta", "LocalMeta", "SnapshotMeta"];
 
     pub fn enum_name_meta_typed(e: MetaTyped) -> &'static str {
         let index = e as u8;
@@ -76,6 +79,86 @@ pub mod commit {
     }
 
     pub struct MetaTypedUnionTableOffset {}
+    pub enum IndexChangeMetaOffset {}
+    #[derive(Copy, Clone, Debug, PartialEq)]
+
+    pub struct IndexChangeMeta<'a> {
+        pub _tab: flatbuffers::Table<'a>,
+    }
+
+    impl<'a> flatbuffers::Follow<'a> for IndexChangeMeta<'a> {
+        type Inner = IndexChangeMeta<'a>;
+        #[inline]
+        fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+            Self {
+                _tab: flatbuffers::Table { buf: buf, loc: loc },
+            }
+        }
+    }
+
+    impl<'a> IndexChangeMeta<'a> {
+        #[inline]
+        pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+            IndexChangeMeta { _tab: table }
+        }
+        #[allow(unused_mut)]
+        pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+            _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+            args: &'args IndexChangeMetaArgs,
+        ) -> flatbuffers::WIPOffset<IndexChangeMeta<'bldr>> {
+            let mut builder = IndexChangeMetaBuilder::new(_fbb);
+            builder.add_last_mutation_id(args.last_mutation_id);
+            builder.finish()
+        }
+
+        pub const VT_LAST_MUTATION_ID: flatbuffers::VOffsetT = 4;
+
+        #[inline]
+        pub fn last_mutation_id(&self) -> u64 {
+            self._tab
+                .get::<u64>(IndexChangeMeta::VT_LAST_MUTATION_ID, Some(0))
+                .unwrap()
+        }
+    }
+
+    pub struct IndexChangeMetaArgs {
+        pub last_mutation_id: u64,
+    }
+    impl<'a> Default for IndexChangeMetaArgs {
+        #[inline]
+        fn default() -> Self {
+            IndexChangeMetaArgs {
+                last_mutation_id: 0,
+            }
+        }
+    }
+    pub struct IndexChangeMetaBuilder<'a: 'b, 'b> {
+        fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+        start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    }
+    impl<'a: 'b, 'b> IndexChangeMetaBuilder<'a, 'b> {
+        #[inline]
+        pub fn add_last_mutation_id(&mut self, last_mutation_id: u64) {
+            self.fbb_
+                .push_slot::<u64>(IndexChangeMeta::VT_LAST_MUTATION_ID, last_mutation_id, 0);
+        }
+        #[inline]
+        pub fn new(
+            _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+        ) -> IndexChangeMetaBuilder<'a, 'b> {
+            let start = _fbb.start_table();
+            IndexChangeMetaBuilder {
+                fbb_: _fbb,
+                start_: start,
+            }
+        }
+        #[inline]
+        pub fn finish(self) -> flatbuffers::WIPOffset<IndexChangeMeta<'a>> {
+            let o = self.fbb_.end_table(self.start_);
+            flatbuffers::WIPOffset::new(o.value())
+        }
+    }
+
     pub enum LocalMetaOffset {}
     #[derive(Copy, Clone, Debug, PartialEq)]
 
@@ -380,6 +463,16 @@ pub mod commit {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<flatbuffers::Table<'a>>>(Meta::VT_TYPED, None)
         }
+        #[inline]
+        #[allow(non_snake_case)]
+        pub fn typed_as_index_change_meta(&self) -> Option<IndexChangeMeta<'a>> {
+            if self.typed_type() == MetaTyped::IndexChangeMeta {
+                self.typed().map(|u| IndexChangeMeta::init_from_table(u))
+            } else {
+                None
+            }
+        }
+
         #[inline]
         #[allow(non_snake_case)]
         pub fn typed_as_local_meta(&self) -> Option<LocalMeta<'a>> {

--- a/src/db/index.rs
+++ b/src/db/index.rs
@@ -7,12 +7,12 @@ use serde_json::Value;
 
 #[derive(Debug)]
 pub struct Index {
-    pub meta: commit::IndexMeta,
+    pub meta: commit::IndexRecord,
     map: RwLock<Option<prolly::Map>>,
 }
 
 impl Index {
-    pub fn new(meta: commit::IndexMeta, map: Option<prolly::Map>) -> Index {
+    pub fn new(meta: commit::IndexRecord, map: Option<prolly::Map>) -> Index {
         Index {
             meta,
             map: RwLock::new(map),

--- a/src/db/index.rs
+++ b/src/db/index.rs
@@ -78,7 +78,7 @@ impl<'a> MapWriteGuard<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum GetMapError {
     MapLoadError(prolly::LoadError),
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -13,7 +13,7 @@ pub mod test_helpers;
 pub use root::{get_root, GetRootError};
 
 pub use commit::{
-    BaseSnapshotError, Commit, FromHashError, IndexMeta, InternalProgrammerError, LocalMeta,
+    BaseSnapshotError, Commit, FromHashError, IndexRecord, InternalProgrammerError, LocalMeta,
     MetaTyped, PendingError, DEFAULT_HEAD_NAME,
 };
 pub use index::{decode_index_key, encode_index_key, encode_scan_key, GetIndexKeysError};

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -14,7 +14,7 @@ pub use root::{get_root, GetRootError};
 
 pub use commit::{
     BaseSnapshotError, Commit, FromHashError, IndexRecord, InternalProgrammerError, LocalMeta,
-    MetaTyped, PendingError, DEFAULT_HEAD_NAME,
+    MetaTyped, WalkChainError, DEFAULT_HEAD_NAME,
 };
 pub use index::{decode_index_key, encode_index_key, encode_scan_key, GetIndexKeysError};
 pub use read::{read_commit, read_indexes, OwnedRead, Read, ReadCommitError, ScanError, Whence};

--- a/src/db/write.rs
+++ b/src/db/write.rs
@@ -289,7 +289,7 @@ impl<'a> Write<'a> {
         self.indexes.insert(
             name,
             index::Index::new(
-                commit::IndexMeta {
+                commit::IndexRecord {
                     definition,
                     value_hash: str!(""),
                 },

--- a/src/embed/types.rs
+++ b/src/embed/types.rs
@@ -3,6 +3,17 @@
 use crate::db;
 use serde::{Deserialize, Serialize};
 
+// Note: index transactions are closed or committed using the regular
+// (Commit|Close)Transaction RPC.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct OpenIndexTransactionRequest {}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct OpenIndexTransactionResponse {
+    #[serde(rename = "transactionId")]
+    pub transaction_id: u32,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct OpenTransactionRequest {
     pub name: Option<String>, // not present in read transactions

--- a/src/prolly/map.rs
+++ b/src/prolly/map.rs
@@ -17,7 +17,7 @@ pub struct Map {
     pending: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum LoadError {
     Storage(dag::Error),
     UnknownHash,
@@ -36,7 +36,7 @@ impl From<leaf::LoadError> for LoadError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum FlushError {
     Storage(dag::Error),
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -181,7 +181,7 @@ pub async fn begin_sync(
     // in chain-head-first order.
     pending.push(base_snapshot_post_pull);
     // Now find the first commit that will not be rebased.
-    let index_metas: Vec<db::IndexMeta> = pending
+    let index_metas: Vec<db::IndexRecord> = pending
         .iter()
         .find(|c| c.mutation_id() <= pull_resp.last_mutation_id)
         .ok_or(InternalInvalidChainError)?

--- a/tool/flatc.sh
+++ b/tool/flatc.sh
@@ -2,6 +2,8 @@
 
 # Simple script to generate Flatbuffer sources from schema files
 # while maintaining rustfmt and Clippy cleanliness.
+# Requires flatc. Easiest way to install on OSX is via homebrew
+# (brew install flatbuffers).
 
 if [ "$1" == "" ]; then
   echo "Usage: flatc.sh foo.fbs"


### PR DESCRIPTION
two separate logical commits. 

@arv this is a breaking change. you now have to open index transactions with openindextransaction. they are closed the same as normal transactions with committransaction. now you can no longer do index changes in regular transactions or put/dels in index transactions. i have separated index change commits into their own commit type separate from local commits. this means that A) index changes are not returned for replay by maybeendsync and B) the customer does not have to have data layer mutators for index changes. yay!

progress towards #218 

closes https://github.com/rocicorp/repc/issues/257