### PR TITLE
scan clean ups and enable scanning indexes by primary key

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -16,9 +16,9 @@ pub use commit::{
     BaseSnapshotError, Commit, FromHashError, IndexRecord, InternalProgrammerError, LocalMeta,
     MetaTyped, WalkChainError, DEFAULT_HEAD_NAME,
 };
-pub use index::{decode_index_key, encode_index_key, encode_scan_key, GetIndexKeysError, IndexKeyOwned};
+pub use index::{decode_index_key, encode_index_key, encode_scan_key, GetIndexKeysError, IndexKey};
 pub use read::{read_commit, read_indexes, OwnedRead, Read, ReadCommitError, ScanError, Whence};
-pub use scan::ScanOptions;
+pub use scan::{ScanItem, ScanOptions, ScanResult, ScanResultError};
 pub use write::{
     init_db, ClearError, CommitError, CreateIndexError, DelError, DropIndexError, InitDBError,
     PutError, Write,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -16,7 +16,9 @@ pub use commit::{
     BaseSnapshotError, Commit, FromHashError, IndexRecord, InternalProgrammerError, LocalMeta,
     MetaTyped, WalkChainError, DEFAULT_HEAD_NAME,
 };
-pub use index::{decode_index_key, encode_index_key, encode_scan_key, GetIndexKeysError, IndexKey};
+pub use index::{
+    decode_index_key, encode_index_key, encode_index_scan_key, GetIndexKeysError, IndexKey,
+};
 pub use read::{read_commit, read_indexes, OwnedRead, Read, ReadCommitError, ScanError, Whence};
 pub use scan::{ScanItem, ScanOptions, ScanResult, ScanResultError};
 pub use write::{

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -16,7 +16,7 @@ pub use commit::{
     BaseSnapshotError, Commit, FromHashError, IndexRecord, InternalProgrammerError, LocalMeta,
     MetaTyped, WalkChainError, DEFAULT_HEAD_NAME,
 };
-pub use index::{decode_index_key, encode_index_key, encode_scan_key, GetIndexKeysError};
+pub use index::{decode_index_key, encode_index_key, encode_scan_key, GetIndexKeysError, IndexKeyOwned};
 pub use read::{read_commit, read_indexes, OwnedRead, Read, ReadCommitError, ScanError, Whence};
 pub use scan::ScanOptions;
 pub use write::{

--- a/src/db/read.rs
+++ b/src/db/read.rs
@@ -110,7 +110,7 @@ impl<'a> Read<'a> {
     pub async fn scan(
         &'a self,
         opts: super::ScanOptions,
-        callback: impl Fn(prolly::Entry<'_>),
+        callback: impl Fn(super::scan::ScanResult<'_>),
     ) -> Result<(), ScanError> {
         use ScanError::*;
 

--- a/src/db/scan.rs
+++ b/src/db/scan.rs
@@ -42,7 +42,7 @@ impl TryFrom<ScanOptions> for ScanOptionsInternal {
         // If the scan is using an index then we need to generate the scan keys.
         let prefix = if let Some(p) = source.prefix {
             if source.index_name.is_some() {
-                super::index::encode_scan_key(&p, false)
+                super::index::encode_scan_key(p.as_bytes(), false)
                     .map_err(ScanOptionsError::CreateScanKeyFailure)?
             } else {
                 p.into_bytes()
@@ -53,7 +53,7 @@ impl TryFrom<ScanOptions> for ScanOptionsInternal {
         };
         let start_key = if let Some(sk) = source.start_key {
             if source.index_name.is_some() {
-                super::index::encode_scan_key(&sk, source.start_key_exclusive.unwrap_or(false))
+                super::index::encode_scan_key(sk.as_bytes(), source.start_key_exclusive.unwrap_or(false))
                     .map_err(ScanOptionsError::CreateScanKeyFailure)?
             } else {
                 sk.into_bytes()

--- a/src/db/write.rs
+++ b/src/db/write.rs
@@ -887,7 +887,7 @@ mod tests {
                 assert_eq!(
                     entries.get(i).unwrap().key,
                     index::encode_index_key(&index::IndexKey {
-                        secondary: format!("s{}", i).as_str(),
+                        secondary: format!("s{}", i).as_bytes(),
                         primary: format!("k{}", i).as_bytes(),
                     })
                     .unwrap()

--- a/src/db/write.rs
+++ b/src/db/write.rs
@@ -301,7 +301,7 @@ impl<'a> Write<'a> {
         }
 
         let mut index_map = prolly::Map::new();
-        for entry in scan::scan(
+        for entry in scan::scan_raw(
             &self.map,
             scan::ScanOptionsInternal {
                 prefix: Some(key_prefix.into()),

--- a/src/db/write.rs
+++ b/src/db/write.rs
@@ -307,7 +307,6 @@ impl<'a> Write<'a> {
                 prefix: Some(key_prefix.into()),
                 limit: None,
                 start_key: None,
-                start_key_exclusive: None,
                 index_name: None,
             },
         ) {

--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -531,9 +531,9 @@ async fn do_scan(
         let secondary_key: JsValue;
         if using_index {
             // TODO the unwrap()s below are really unfortunate
-            let (secondary, primary) = db::index::decode_index_key(pe.key).unwrap();
+            let db::IndexKeyOwned { secondary, primary } = db::index::decode_index_key(pe.key).unwrap();
             primary_key = JsValue::from_str(std::str::from_utf8(&primary).unwrap());
-            secondary_key = JsValue::from_str(&secondary);
+            secondary_key = JsValue::from_str(std::str::from_utf8(&secondary).unwrap())
         } else {
             primary_key = JsValue::from_str(std::str::from_utf8(pe.key).unwrap());
             secondary_key = JsValue::null();

--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -535,18 +535,19 @@ async fn do_scan(
                         .call3(&JsValue::null(), &primary_key, &secondary_key, &val)
                         .unwrap();
                 } else {
-                    primary_key_string
-                        .err()
-                        .map(|e| error!(lc, "Error parsing primary key: {:?}", e));
-                    secondary_key_string
-                        .err()
-                        .map(|e| error!(lc, "Error parsing secondary key: {:?}", e));
+                    if let Some(e) = primary_key_string.err() {
+                        error!(lc, "Error parsing primary key: {:?}", e);
+                    }
+                    if let Some(e) = secondary_key_string.err() {
+                        error!(lc, "Error parsing secondary key: {:?}", e);
+                    }
                 }
             }
         }
     })
     .await
     .map_err(ScanError::ScanError)?;
+
     Ok(ScanResponse {})
 }
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -490,7 +490,6 @@ mod tests {
     use super::*;
     use crate::db::test_helpers::*;
     use crate::kv::memstore::MemStore;
-    use crate::prolly;
     use crate::util::rlog::LogContext;
     use crate::util::to_debug;
     use async_std::net::TcpListener;
@@ -940,7 +939,7 @@ mod tests {
                             limit: None,
                             index_name: Some(str!("2")),
                         },
-                        |_: prolly::Entry<'_>| {
+                        |_: db::ScanResult<'_>| {
                             *got.borrow_mut() = true;
                         },
                     )
@@ -1078,8 +1077,8 @@ mod tests {
                                     limit: None,
                                     index_name: Some(str!("2")),
                                 },
-                                |pe: prolly::Entry<'_>| {
-                                    assert!(false, "{}: expected no values, got {:?}", c.name, pe);
+                                |sr: db::ScanResult<'_>| {
+                                    assert!(false, "{}: expected no values, got {:?}", c.name, sr);
                                 },
                             )
                             .await

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -934,8 +934,9 @@ mod tests {
                     .scan(
                         db::ScanOptions {
                             prefix: Some(str!("")),
+                            start_secondary_key: None,
                             start_key: None,
-                            start_key_exclusive: None,
+                            start_exclusive: None,
                             limit: None,
                             index_name: Some(str!("2")),
                         },
@@ -1072,8 +1073,9 @@ mod tests {
                             .scan(
                                 db::ScanOptions {
                                     prefix: Some(str!("")),
+                                    start_secondary_key: None,
                                     start_key: None,
-                                    start_key_exclusive: None,
+                                    start_exclusive: None,
                                     limit: None,
                                     index_name: Some(str!("2")),
                                 },

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -437,7 +437,7 @@ async fn test_create_drop_index() {
     let transaction_id = open_transaction(db, "foo".to_string().into(), Some(json!([])), None)
         .await
         .transaction_id;
-    let expected = vec![(str!("boo"), Some(str!("foo")), str!(r#"{"s": "foo"}"#))];
+    let expected = vec![(str!("boo"), str!("foo"), str!(r#"{"s": "foo"}"#))];
     {
         let (receive, _cb, got) = new_test_scan_receiver();
         scan(db, transaction_id, "", "", false, Some("idx1"), receive).await;
@@ -517,11 +517,11 @@ async fn test_scan() {
         prefix: &str,
         start_key: &str,
         exclusive: bool,
-        expected: Vec<(&str, Option<&str>, &str)>,
+        expected: Vec<(&str, &str, &str)>,
     ) {
-        let expected: Vec<(String, Option<String>, String)> = expected
+        let expected: Vec<(String, String, String)> = expected
             .iter()
-            .map(|v| (str!(v.0), v.1.map(|s| str!(s)), str!(v.2)))
+            .map(|v| (str!(v.0), str!(v.1), str!(v.2)))
             .collect();
 
         let db = &random_db();
@@ -558,7 +558,7 @@ async fn test_scan() {
         "",
         "",
         false,
-        vec![("foo", None, "bar")],
+        vec![("foo", "", "bar")],
     )
     .await;
     test(
@@ -567,7 +567,7 @@ async fn test_scan() {
         "",
         "",
         false,
-        vec![("foo", None, "bar")],
+        vec![("foo", "", "bar")],
     )
     .await;
     test(
@@ -576,7 +576,7 @@ async fn test_scan() {
         "f",
         "",
         false,
-        vec![("foo", None, "bar")],
+        vec![("foo", "", "bar")],
     )
     .await;
     test(
@@ -585,7 +585,7 @@ async fn test_scan() {
         "foo",
         "",
         false,
-        vec![("foo", None, "bar")],
+        vec![("foo", "", "bar")],
     )
     .await;
     test(vec![("foo", "bar")], true, "nomatch", "", false, vec![]).await;
@@ -593,10 +593,10 @@ async fn test_scan() {
     // several entries
     let entries = vec![("c", "cv"), ("aa", "aav"), ("a", "av"), ("b", "bv")];
     let expected = vec![
-        ("a", None, "av"),
-        ("aa", None, "aav"),
-        ("b", None, "bv"),
-        ("c", None, "cv"),
+        ("a", "", "av"),
+        ("aa", "", "aav"),
+        ("b", "", "bv"),
+        ("c", "", "cv"),
     ];
     test(entries.clone(), false, "", "", false, expected.clone()).await;
     test(entries.clone(), true, "", "", false, expected.clone()).await;
@@ -659,12 +659,12 @@ async fn test_scan_with_index() {
         prefix: &str,            // scan prefix
         start_key: &str,         // scan start key
         exclusive: bool,         // scan start exclusive
-        expected: Vec<(&str, Option<&str>, &str)>, // expected results of the scan
+        expected: Vec<(&str, &str, &str)>, // expected results of the scan
     ) {
         let index_name = str!("idx1");
-        let expected: Vec<(String, Option<String>, String)> = expected
+        let expected: Vec<(String, String, String)> = expected
             .iter()
-            .map(|v| (str!(v.0), v.1.map(|s| str!(s)), str!(v.2)))
+            .map(|v| (str!(v.0), str!(v.1), str!(v.2)))
             .collect();
 
         let db = &random_db();
@@ -741,7 +741,7 @@ async fn test_scan_with_index() {
             "",
             "",
             false,
-            vec![("", Some("value"), r#""value""#)],
+            vec![("", "value", r#""value""#)],
         )
         .await;
     }
@@ -758,7 +758,7 @@ async fn test_scan_with_index() {
             "",
             "",
             false,
-            vec![("key", Some("value"), r#""value""#)],
+            vec![("key", "value", r#""value""#)],
         )
         .await;
         // Scan an indexed array
@@ -772,8 +772,8 @@ async fn test_scan_with_index() {
             "",
             false,
             vec![
-                ("key", Some("value1"), r#"{"s": ["value1", "value2"]}"#),
-                ("key", Some("value2"), r#"{"s": ["value1", "value2"]}"#),
+                ("key", "value1", r#"{"s": ["value1", "value2"]}"#),
+                ("key", "value2", r#"{"s": ["value1", "value2"]}"#),
             ],
         )
         .await;
@@ -813,7 +813,7 @@ async fn test_scan_with_index() {
             "v",
             "",
             false,
-            vec![("key", Some("value"), r#""value""#)],
+            vec![("key", "value", r#""value""#)],
         )
         .await;
         // scan prefix exactly matches indexed value
@@ -826,7 +826,7 @@ async fn test_scan_with_index() {
             "value",
             "",
             false,
-            vec![("key", Some("value"), r#""value""#)],
+            vec![("key", "value", r#""value""#)],
         )
         .await;
         // scan prefix does not match indexed value
@@ -852,7 +852,7 @@ async fn test_scan_with_index() {
             "",
             "v",
             false,
-            vec![("key", Some("value"), r#""value""#)],
+            vec![("key", "value", r#""value""#)],
         )
         .await;
         // scan start key matches indexed value
@@ -865,7 +865,7 @@ async fn test_scan_with_index() {
             "",
             "value",
             false,
-            vec![("key", Some("value"), r#""value""#)],
+            vec![("key", "value", r#""value""#)],
         )
         .await;
         // scan start key does not match indexed value
@@ -889,9 +889,9 @@ async fn test_scan_with_index() {
             ("bb", r#"{"s": "bb"}"#),
         ];
         let expected = vec![
-            ("a", Some("a"), r#"{"s": "a"}"#),
-            ("aa", Some("aa"), r#"{"s": "aa"}"#),
-            ("bb", Some("bb"), r#"{"s": "bb"}"#),
+            ("a", "a", r#"{"s": "a"}"#),
+            ("aa", "aa", r#"{"s": "aa"}"#),
+            ("bb", "bb", r#"{"s": "bb"}"#),
         ];
         test(
             entries.clone(),
@@ -944,7 +944,7 @@ async fn test_scan_with_index() {
             "",
             "",
             false,
-            vec![("key", Some("value"), r#""value""#)],
+            vec![("key", "value", r#""value""#)],
         )
         .await;
         // replace a value
@@ -957,7 +957,7 @@ async fn test_scan_with_index() {
             "",
             "",
             false,
-            vec![("key", Some("NEW"), r#"{"s": "NEW"}"#)],
+            vec![("key", "NEW", r#"{"s": "NEW"}"#)],
         )
         .await;
     }
@@ -970,9 +970,9 @@ async fn test_scan_with_index() {
         ("key", r#"{"s": "value1"}"#),
     ];
     let expected = vec![
-        ("key", Some("value1"), r#"{"s": "value1"}"#),
-        ("key1", Some("value2"), r#"{"s": "value2"}"#),
-        ("key11", Some("value3"), r#"{"s": "value3"}"#),
+        ("key", "value1", r#"{"s": "value1"}"#),
+        ("key1", "value2", r#"{"s": "value2"}"#),
+        ("key11", "value3", r#"{"s": "value3"}"#),
     ];
     test(entries, "", "/s", Op::None, false, "", "", false, expected).await;
 }
@@ -986,13 +986,13 @@ async fn test_scan_with_index() {
 fn new_test_scan_receiver() -> (
     js_sys::Function,
     Closure<dyn FnMut(JsValue, JsValue, JsValue) -> Result<JsValue, JsValue>>,
-    Rc<RefCell<Vec<(String, Option<String>, String)>>>,
+    Rc<RefCell<Vec<(String, String, String)>>>,
 ) {
     // got_scan_items holds (key, Option<secondary_key>, value) tuples received from scan. It is
     // wrapped in an Rc because Closure otherwise requires a 'static lifetime. It is wrapped
     // in a RefCell to allow the closure to mutate the contents: borrow checker can't prove
     // closure's access is safe, but we know it is, so this moves the check to runtime.
-    let got_scan_items: Rc<RefCell<Vec<(String, Option<String>, String)>>> =
+    let got_scan_items: Rc<RefCell<Vec<(String, String, String)>>> =
         Rc::new(RefCell::new(Vec::new()));
 
     // receiver is passed to dispatch and receives scan items one at a time from scan(). It stores
@@ -1004,11 +1004,7 @@ fn new_test_scan_receiver() -> (
     let closure_got_scan_items = got_scan_items.clone();
     let receiver = move |pk: JsValue, sk: JsValue, v: JsValue| -> Result<JsValue, JsValue> {
         let primary_key = pk.as_string().unwrap();
-        let secondary_key = if sk.is_string() {
-            Some(sk.as_string().unwrap())
-        } else {
-            None
-        };
+        let secondary_key = sk.as_string().unwrap();
         let v: js_sys::Uint8Array = v.into();
         let val = String::from_utf8(v.to_vec()).unwrap();
         closure_got_scan_items


### PR DESCRIPTION
separate logical commits

@arv this is an interface change. 
1.  start_key_exclusive => start_exclusive
2. for index scans we previously passed the secondary key value we are scanning for in start_key. however, we want to enable scanning indexes by both primary and secondary key values. so now you need to pass the secondary key value to scan for in start_secondary_key and the primary key value if any in start_key. note that for index scans the primary key (start_key) is optional and should be omitted entirely from the serialized form if not used. see comment in last commit but the difference is that in index scans specifying start_key forces an exact match on start_secondary_key. if this is too confusing then we can add a separate field.

progress towards #218 

closes https://github.com/rocicorp/repc/issues/259