### PR TITLE
Revert "Remove local_create_date from flat buffer (#268)"

### DIFF
--- a/src/db/commit.fbs
+++ b/src/db/commit.fbs
@@ -34,6 +34,7 @@ union MetaTyped {
 
 // Commit metadata.
 table Meta {
+    local_create_date: string (deprecated);
     basis_hash: string;
     checksum: string;
     typed: MetaTyped;

--- a/src/db/commit_generated.rs
+++ b/src/db/commit_generated.rs
@@ -437,10 +437,10 @@ pub mod commit {
             builder.finish()
         }
 
-        pub const VT_BASIS_HASH: flatbuffers::VOffsetT = 4;
-        pub const VT_CHECKSUM: flatbuffers::VOffsetT = 6;
-        pub const VT_TYPED_TYPE: flatbuffers::VOffsetT = 8;
-        pub const VT_TYPED: flatbuffers::VOffsetT = 10;
+        pub const VT_BASIS_HASH: flatbuffers::VOffsetT = 6;
+        pub const VT_CHECKSUM: flatbuffers::VOffsetT = 8;
+        pub const VT_TYPED_TYPE: flatbuffers::VOffsetT = 10;
+        pub const VT_TYPED: flatbuffers::VOffsetT = 12;
 
         #[inline]
         pub fn basis_hash(&self) -> Option<&'a str> {

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1251,7 +1251,7 @@ async fn test_get_root() {
             .await
             .unwrap(),
         GetRootResponse {
-            root: str!("hpj7r83bbeag40t6ace8uscu80s3rnac"),
+            root: str!("3hjt1p4m1emdttgrii2p0o3te1kt8rhv"),
         }
     );
     let txn_id = open_transaction(db, "foo".to_string().into(), Some(json!([])), None)
@@ -1264,7 +1264,7 @@ async fn test_get_root() {
             .await
             .unwrap(),
         GetRootResponse {
-            root: str!("tolk0qdm4qig4lt9ksjg8mo5fe6belu6"),
+            root: str!("8tnlpltjbt23hc0v8h3td7ssflsnot84"),
         }
     );
     assert_eq!(dispatch::<_, String>(db, "close", "").await.unwrap(), "");


### PR DESCRIPTION
This reverts commit e7e33b4902ea0fea3cd11be76c7cf4e933920138.

Reverting because this is a breaking change and we have a customer in production.

Re-opens #249 