### PR TITLE
Prevent one copy when doing get from IDB

### DIFF
--- a/src/kv/idbstore.rs
+++ b/src/kv/idbstore.rs
@@ -225,7 +225,7 @@ async fn get_impl(tx: &IdbTransaction, key: &str, lc: LogContext) -> Result<Opti
     receiver.await?;
     Ok(match request.result()? {
         v if v.is_undefined() => None,
-        v => Some(js_sys::Uint8Array::new(&v).to_vec()),
+        v => Some(v.unchecked_into::<js_sys::Uint8Array>().to_vec()),
     })
 }
 


### PR DESCRIPTION
We store `Uint8Array`s in IDB. So when we do a `get` we get an
`Uint8Array` out. No need to call `new Uint8Array(value)` again which
does memcopy.