### PR TITLE
Rename sync_id to request_id

### DIFF
--- a/src/embed/connection.rs
+++ b/src/embed/connection.rs
@@ -641,7 +641,7 @@ async fn do_maybe_end_try_pull<'a, 'b>(
     ctx: Context<'a, 'b>,
     req: sync::MaybeEndTryPullRequest,
 ) -> Result<sync::MaybeEndTryPullResponse, sync::MaybeEndTryPullError> {
-    ctx.lc.add_context("sync_id", &req.sync_id);
+    ctx.lc.add_context("request_id", &req.request_id);
     sync::maybe_end_try_pull(ctx.store, ctx.lc.clone(), req).await
 }
 
@@ -666,11 +666,11 @@ async fn do_try_push<'a, 'b>(
     // TODO move client, pusher up to process() or into a lazy static so we can share.
     let fetch_client = fetch::client::Client::new();
     let pusher = sync::FetchPusher::new(&fetch_client);
-    let sync_id = sync::sync_id::new(&ctx.client_id);
-    ctx.lc.add_context("sync_id", &sync_id);
+    let request_id = sync::request_id::new(&ctx.client_id);
+    ctx.lc.add_context("request_id", &request_id);
 
     let http_request_info =
-        sync::push(&sync_id, ctx.store, ctx.lc, ctx.client_id, &pusher, req).await?;
+        sync::push(&request_id, ctx.store, ctx.lc, ctx.client_id, &pusher, req).await?;
     Ok(sync::TryPushResponse { http_request_info })
 }
 
@@ -681,9 +681,9 @@ async fn do_begin_try_pull<'a, 'b>(
     // TODO move client, pusher up to process() or into a lazy static so we can share.
     let fetch_client = fetch::client::Client::new();
     let puller = sync::FetchPuller::new(&fetch_client);
-    let sync_id = sync::sync_id::new(&ctx.client_id);
-    ctx.lc.add_context("sync_id", &sync_id);
-    sync::begin_pull(ctx.client_id, req, &puller, sync_id, ctx.store, ctx.lc).await
+    let request_id = sync::request_id::new(&ctx.client_id);
+    ctx.lc.add_context("request_id", &request_id);
+    sync::begin_pull(ctx.client_id, req, &puller, request_id, ctx.store, ctx.lc).await
 }
 
 #[derive(Debug)]

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -4,7 +4,7 @@ pub mod client_id;
 mod patch;
 mod pull;
 mod push;
-pub mod sync_id;
+pub mod request_id;
 #[cfg(test)]
 pub mod test_helpers;
 mod types;

--- a/src/sync/request_id.rs
+++ b/src/sync/request_id.rs
@@ -16,9 +16,9 @@ lazy_static! {
     static ref SYNC_COUNTERS: Mutex<HashMap<String, AtomicU32>> = Mutex::new(HashMap::new());
 }
 
-// new() returns a new syncid of the form <clientid>-<sessionid>-<sync count>.
+// new() returns a new request_id of the form <clientid>-<sessionid>-<sync count>.
 // The sync count enables one to find the sync following or preceeding a given
-// sync. The sessionid scopes the sync count, ensuring the syncid is
+// sync. The sessionid scopes the sync count, ensuring the request_id is
 // probabilistically unique across restarts (which is good enough).
 pub fn new(client_id: &str) -> String {
     let mut map = match SYNC_COUNTERS.lock() {

--- a/src/sync/types.rs
+++ b/src/sync/types.rs
@@ -15,8 +15,8 @@ pub struct HttpRequestInfo {
 
 #[derive(Deserialize, Serialize)]
 pub struct MaybeEndTryPullRequest {
-    #[serde(rename = "syncID")]
-    pub sync_id: String,
+    #[serde(rename = "requestID")]
+    pub request_id: String,
     #[serde(rename = "syncHead")]
     pub sync_head: String,
 }
@@ -57,8 +57,8 @@ pub struct BeginTryPullResponse {
     pub http_request_info: HttpRequestInfo,
     #[serde(rename = "syncHead")]
     pub sync_head: String,
-    #[serde(rename = "syncID")]
-    pub sync_id: String,
+    #[serde(rename = "requestID")]
+    pub request_id: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1404,7 +1404,7 @@ async fn test_browser_fetch() {
         &pull_req,
         "https://account-service.rocicorp.now.sh/api/hello",
         "auth",
-        "sync_id",
+        "request_id",
     )
     .unwrap();
     let client = fetch::client::Client::new();


### PR DESCRIPTION
pull and push already got new own IDS when I changed from sync to
pull/push.

Towards #290