### PR TITLE
change cookie from string to JSON

### DIFF
--- a/src/db/commit.fbs
+++ b/src/db/commit.fbs
@@ -22,7 +22,7 @@ table LocalMeta {
 // Commit metadata specific to snapshot commits.
 table SnapshotMeta {
     last_mutation_id: ulong;
-    cookie: string;
+    cookie_json: [ubyte];
 }
 
 // Commit metadata specific to the type of commit.

--- a/src/db/commit_generated.rs
+++ b/src/db/commit_generated.rs
@@ -327,14 +327,14 @@ pub mod commit {
         ) -> flatbuffers::WIPOffset<SnapshotMeta<'bldr>> {
             let mut builder = SnapshotMetaBuilder::new(_fbb);
             builder.add_last_mutation_id(args.last_mutation_id);
-            if let Some(x) = args.cookie {
-                builder.add_cookie(x);
+            if let Some(x) = args.cookie_json {
+                builder.add_cookie_json(x);
             }
             builder.finish()
         }
 
         pub const VT_LAST_MUTATION_ID: flatbuffers::VOffsetT = 4;
-        pub const VT_COOKIE: flatbuffers::VOffsetT = 6;
+        pub const VT_COOKIE_JSON: flatbuffers::VOffsetT = 6;
 
         #[inline]
         pub fn last_mutation_id(&self) -> u64 {
@@ -343,22 +343,26 @@ pub mod commit {
                 .unwrap()
         }
         #[inline]
-        pub fn cookie(&self) -> Option<&'a str> {
+        pub fn cookie_json(&self) -> Option<&'a [u8]> {
             self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(SnapshotMeta::VT_COOKIE, None)
+                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
+                    SnapshotMeta::VT_COOKIE_JSON,
+                    None,
+                )
+                .map(|v| v.safe_slice())
         }
     }
 
     pub struct SnapshotMetaArgs<'a> {
         pub last_mutation_id: u64,
-        pub cookie: Option<flatbuffers::WIPOffset<&'a str>>,
+        pub cookie_json: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
     }
     impl<'a> Default for SnapshotMetaArgs<'a> {
         #[inline]
         fn default() -> Self {
             SnapshotMetaArgs {
                 last_mutation_id: 0,
-                cookie: None,
+                cookie_json: None,
             }
         }
     }
@@ -373,9 +377,14 @@ pub mod commit {
                 .push_slot::<u64>(SnapshotMeta::VT_LAST_MUTATION_ID, last_mutation_id, 0);
         }
         #[inline]
-        pub fn add_cookie(&mut self, cookie: flatbuffers::WIPOffset<&'b str>) {
-            self.fbb_
-                .push_slot_always::<flatbuffers::WIPOffset<_>>(SnapshotMeta::VT_COOKIE, cookie);
+        pub fn add_cookie_json(
+            &mut self,
+            cookie_json: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>,
+        ) {
+            self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+                SnapshotMeta::VT_COOKIE_JSON,
+                cookie_json,
+            );
         }
         #[inline]
         pub fn new(

--- a/src/db/test_helpers.rs
+++ b/src/db/test_helpers.rs
@@ -93,7 +93,7 @@ pub async fn add_snapshot<'a>(
     map: Option<Vec<String>>,
 ) -> &'a mut Chain {
     assert!(chain.len() > 0);
-    let cookie = format!("cookie_{}", chain.len());
+    let cookie = serde_json::json!(format!("cookie_{}", chain.len()));
     let mut w = Write::new_snapshot(
         Whence::Head(str!(db::DEFAULT_HEAD_NAME)),
         chain[chain.len() - 1].next_mutation_id(),

--- a/src/sync/patch.rs
+++ b/src/sync/patch.rs
@@ -81,7 +81,6 @@ mod tests {
     use crate::util::rlog::LogContext;
     use crate::util::to_debug;
     use std::collections::HashMap;
-    use str_macro::str;
 
     macro_rules! map(
         { $($key:expr => $value:expr),+ } => {
@@ -202,7 +201,7 @@ mod tests {
             let mut db_write = db::Write::new_snapshot(
                 db::Whence::Hash(chain[0].chunk().hash().to_string()),
                 1,
-                str!("cookie"),
+                json!("cookie"),
                 dag_write,
                 db::read_indexes(&chain[0]),
             )

--- a/src/sync/pull.rs
+++ b/src/sync/pull.rs
@@ -273,7 +273,8 @@ pub async fn maybe_end_try_pull(
 pub struct PullRequest {
     #[serde(rename = "clientID")]
     pub client_id: String,
-    pub cookie: String,
+    #[serde(default)]
+    pub cookie: serde_json::Value,
     #[serde(rename = "lastMutationID")]
     pub last_mutation_id: u64,
     #[serde(rename = "pullVersion")]
@@ -283,7 +284,8 @@ pub struct PullRequest {
 #[derive(Deserialize)]
 #[cfg_attr(test, derive(Clone, Debug, PartialEq))]
 pub struct PullResponse {
-    pub cookie: String,
+    #[serde(default)]
+    pub cookie: serde_json::Value,
     #[serde(rename = "lastMutationID")]
     pub last_mutation_id: u64,
     pub patch: Vec<patch::Operation>,
@@ -399,7 +401,7 @@ mod tests {
         lazy_static! {
             static ref PULL_REQ: PullRequest = PullRequest {
                 client_id: str!("client_id"),
-                cookie: str!("cookie"),
+                cookie: json!("cookie"),
                 last_mutation_id: 123,
                 pull_version: PULL_VERSION,
             };
@@ -429,7 +431,7 @@ mod tests {
                 }"#,
                 exp_err: None,
                 exp_resp: Some(PullResponse {
-                    cookie: str!("1"),
+                    cookie: json!("1"),
                     last_mutation_id: 2,
                     patch: vec![Operation {
                         op: str!("replace"),
@@ -556,7 +558,7 @@ mod tests {
         // last_mutation_id. Tests can clone it and override those
         // fields they wish to change. This minimizes test changes required
         // when PullResponse changes.
-        let new_cookie = str!("new_cookie");
+        let new_cookie = json!("new_cookie");
         let good_pull_resp = PullResponse {
             cookie: new_cookie.clone(),
             last_mutation_id: 10,
@@ -577,7 +579,7 @@ mod tests {
         let good_pull_resp_value_map = map!("/new" => "\"value\"");
 
         struct ExpCommit<'a> {
-            cookie: String,
+            cookie: serde_json::Value,
             last_mutation_id: u64,
             value_map: HashMap<&'a str, &'a str>,
             indexes: Vec<String>,
@@ -721,13 +723,13 @@ mod tests {
                 num_pending_mutations: 0,
                 pull_result: Ok(PullResponse {
                     last_mutation_id: base_last_mutation_id,
-                    cookie: str!("new_cookie"),
+                    cookie: json!("new_cookie"),
                     patch: vec![],
                     ..good_pull_resp.clone()
                 }),
                 exp_err: None,
                 exp_new_sync_head: Some(ExpCommit {
-                    cookie: str!("new_cookie"),
+                    cookie: json!("new_cookie"),
                     last_mutation_id: base_last_mutation_id,
                     value_map: base_value_map.clone(),
                     indexes: vec![2.to_string()],
@@ -1120,7 +1122,7 @@ mod tests {
             let w = db::Write::new_snapshot(
                 db::Whence::Hash(chain[0].chunk().hash().to_string()),
                 0,
-                str!("sync_cookie"),
+                json!("sync_cookie"),
                 dag_write,
                 db::read_indexes(&chain[0]),
             )

--- a/src/sync/test_helpers.rs
+++ b/src/sync/test_helpers.rs
@@ -35,7 +35,7 @@ pub async fn add_sync_snapshot<'a>(
     let mut sync_chain: Chain = vec![];
 
     // Add sync snapshot.
-    let cookie = format!("sync_cookie_{}", chain.len());
+    let cookie = serde_json::json!(format!("sync_cookie_{}", chain.len()));
     let indexes = db::read_indexes(&chain[take_indexes_from]);
     let w = db::Write::new_snapshot(
         Whence::Hash(base_snapshot.chunk().hash().to_string()),

--- a/src/sync/types.rs
+++ b/src/sync/types.rs
@@ -96,6 +96,7 @@ pub enum BeginTryPullError {
     InternalProgrammerError(db::InternalProgrammerError),
     InternalRebuildIndexError(db::CreateIndexError),
     InternalTimerError(rlog::TimerError),
+    InvalidBaseSnapshotCookie(serde_json::error::Error),
     LockError(dag::Error),
     MainHeadDisappeared,
     NoBaseSnapshot(db::BaseSnapshotError),

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1311,7 +1311,7 @@ async fn test_get_root() {
                 .await
                 .unwrap(),
             GetRootResponse {
-                root: str!("ea36gk12373k629dr3gefo5ttk1kooo2"),
+                root: str!("0rq1efi2innh6ci15bsf3td7rr0luqme"),
             }
         );
         let txn_id = open_transaction(db, "foo".to_string().into(), Some(json!([])), None)
@@ -1324,7 +1324,7 @@ async fn test_get_root() {
                 .await
                 .unwrap(),
             GetRootResponse {
-                root: str!("qavpf4bm1l1mos2o9horifhk52fiq44i"),
+                root: str!("jle0ntqmldmrl88v7niv5i5qpqq0h1b1"),
             }
         );
         assert_eq!(dispatch::<_, String>(db, "close", "").await.unwrap(), "");


### PR DESCRIPTION
the cookie defaults to `null`, which is the value that will be sent with the first PullRequest, and will be the default if the cookie is missing from the PullRequest/Response. If we want to change it to "" or something else we just have to update the  `#[serde(default)]` on the field in the request and response.

progress towards https://github.com/rocicorp/repc/issues/290