### PR TITLE
Add overlappingRequests flag to "open"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.1",
+ "pin-project",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -926,7 +926,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.1",
+ "pin-project",
  "tokio",
  "tower-service",
  "tracing",
@@ -946,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -986,9 +986,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1156,31 +1156,11 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
-dependencies = [
- "pin-project-internal 0.4.27",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
 dependencies = [
- "pin-project-internal 1.0.1",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -1824,9 +1804,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.23"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
  "bytes",
  "fnv",
@@ -1878,11 +1858,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-futures"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 0.4.27",
+ "pin-project",
  "tracing",
 ]
 
@@ -2002,11 +1982,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -2014,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2041,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2051,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2064,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -2094,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tokio = { version = "0.2", features = ["io-util"] } # For hyper.
 tide = "0.12.0"
 
 [dependencies.web-sys]
-version = "0.3.40"
+version = "0.3.48"
 features = [
     "console",
     "Crypto",
@@ -70,6 +70,7 @@ features = [
     "IdbTransactionMode",
     "IdbVersionChangeEvent",
     "Performance",
+    "PerformanceResourceTiming",
     "Request",
     "RequestInit",
     "RequestMode",

--- a/src/embed/dispatch.rs
+++ b/src/embed/dispatch.rs
@@ -146,6 +146,7 @@ async fn do_open(conns: &mut ConnMap, req: &Request) -> Response {
         dag::Store::new(kv),
         rx,
         client_id.clone(),
+        open_req.overlapping_requests,
         req.lc.clone(),
     ));
     conns.insert(req.db_name.clone(), tx);

--- a/src/embed/types.rs
+++ b/src/embed/types.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct OpenRequest {
+    #[serde(rename = "overlappingRequests")]
+    pub overlapping_requests: bool,
     #[serde(rename = "useMemstore")]
     pub use_memstore: bool,
 }

--- a/src/fetch/rust_client.rs
+++ b/src/fetch/rust_client.rs
@@ -28,11 +28,11 @@ impl Client {
         }
     }
 
-    // request() makes an HTTP request using a native rust HTTP client, as opposed
-    // to using the browser's Fetch API in wasm. It consumes its request input by design.
-    // The response returned will have the status and body set but not the headers,
-    // but only because we haven't writtent that code. Non-200 status code does not
-    // constitute an Err Result.
+    // request() makes an HTTP request using a native rust HTTP client, as
+    // opposed to using the browser's Fetch API in wasm. It consumes its request
+    // input by design. The response returned will have the version, status and
+    // body set but not the headers, but only because we haven't writtent that
+    // code. Non-200 status code does not constitute an Err Result.
     //     _ _   ____  ________          __     _____  ______   _ _
     //    | | | |  _ \|  ____\ \        / /\   |  __ \|  ____| | | |
     //    | | | | |_) | |__   \ \  /\  / /  \  | |__) | |__    | | |
@@ -40,8 +40,8 @@ impl Client {
     //    |_|_| | |_) | |____   \  /\  / ____ \| | \ \| |____  |_|_|
     //    (_|_) |____/|______|   \/  \/_/    \_\_|  \_\______| (_|_)
     //
-    // IF YOU CHANGE THE BEHAVIOR OR CAPABILITIES OF THIS FUNCTION please be sure to reflect
-    // the same changes into the browser client.
+    // IF YOU CHANGE THE BEHAVIOR OR CAPABILITIES OF THIS FUNCTION please be
+    // sure to reflect the same changes into the browser client.
     //
     // TODO log req/resp
     pub async fn request(
@@ -57,6 +57,7 @@ impl Client {
     ) -> Result<http::Response<String>, FetchError> {
         let (parts, req_body) = http_req.into_parts();
         let mut builder = hyper::Request::builder()
+            // TODO: Use HTTP/2 when we have upgraded hyper?
             .method(parts.method.as_str())
             .uri(&parts.uri.to_string());
         for (k, v) in parts.headers.iter() {
@@ -83,6 +84,7 @@ impl Client {
                 .map_err(|e| ErrorReadingResponseBodyAsString(to_debug(e)))?;
         let http_resp = http_resp_builder
             .status(hyper_resp.status())
+            .version(hyper_resp.version())
             .body(http_resp_string)
             .map_err(|e| FailedToWrapHttpResponse(to_debug(e)))?;
         Ok(http_resp)

--- a/src/sync/http_request.rs
+++ b/src/sync/http_request.rs
@@ -1,0 +1,36 @@
+use serde::Serialize;
+
+#[derive(Debug)]
+pub enum RequestError {
+    InvalidRequest(http::Error),
+    SerializeRequestError(serde_json::error::Error),
+}
+
+pub fn new_http_request<Request>(
+    req: &Request,
+    url: &str,
+    auth: &str,
+    request_id: &str,
+    overlapping_requests: bool,
+) -> Result<http::Request<String>, RequestError>
+where
+    Request: Serialize,
+{
+    use RequestError::*;
+    let body = serde_json::to_string(req).map_err(SerializeRequestError)?;
+    let builder = http::request::Builder::new();
+    let http_req = builder
+        .version(if overlapping_requests {
+            http::Version::HTTP_2
+        } else {
+            http::Version::default()
+        })
+        .method("POST")
+        .uri(url)
+        .header("Content-type", "application/json")
+        .header("Authorization", auth)
+        .header("X-Replicache-RequestID", request_id)
+        .body(body)
+        .map_err(InvalidRequest)?;
+    Ok(http_req)
+}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::redundant_pattern_matching)] // For derive(Deserialize).
 
 pub mod client_id;
+mod http_request;
 mod patch;
 mod pull;
 mod push;
@@ -8,6 +9,7 @@ pub mod request_id;
 #[cfg(test)]
 pub mod test_helpers;
 mod types;
+pub use http_request::*;
 pub use pull::*;
 pub use push::*;
 pub use types::*;

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1490,7 +1490,7 @@ async fn test_browser_fetch() {
         client_id: str!("1"),
         ..Default::default()
     };
-    let http_req = sync::new_pull_http_request(
+    let http_req = sync::new_http_request(
         &pull_req,
         "https://replicache-sample-todo.now.sh/serve/replicache-client-view",
         "1",


### PR DESCRIPTION
When overlappingRequests is true it is in an error if the pull/push
endpoint uses HTTP1/x. It needs to use H2 or H3.

fetch/rust_client.rs is not really working with this change since it
uses hyper 0.13 which does not support HTTP/2. There is a newer version
of hyper that supports h2 but hyper runs on top of tokio and we use std
async. We have a compat file but I could not get it to work correctly. I
need to spend more time on this if we ever want to support non web.

I tested the browser fetch path manually.

https://www.notion.so/Push-pull-scheduling-268fd33bbcf14c5cbced55a249f409aa#c959432fc61a4c4bb152aa61e3856f44

Towards https://github.com/rocicorp/replicache-sdk-js/issues/294