### PR TITLE
Use durability relaxed for write transactions 

### DIFF
--- a/src/kv/idbstore.js
+++ b/src/kv/idbstore.js
@@ -1,0 +1,39 @@
+// @ts-check
+
+const RELAXED = {durability: "relaxed"};
+
+const OBJECT_STORE = "chunks";
+
+/**
+ * @param {IDBDatabase} idb
+ * @return {IDBTransaction}
+ */
+export function readTransaction(idb) {
+  return idb.transaction(OBJECT_STORE, "readwrite");
+}
+
+/**
+ * @param {IDBDatabase} idb
+ * @return {IDBTransaction}
+ */
+export function writeTransaction(idb) {
+  // TS does not have type defs for the third options argument yet.
+  // @ts-ignore Expected 1-2 arguments, but got 3.ts(2554)
+  return idb.transaction(OBJECT_STORE, "readwrite", RELAXED);
+}
+
+/**
+ * @param {IDBTransaction} tx
+ * @return {IDBObjectStore }
+ */
+export function objectStore(tx) {
+  return tx.objectStore(OBJECT_STORE);
+}
+
+/**
+ * @param {IDBDatabase} idb
+ * @return {IDBObjectStore}
+ */
+export function createObjectStore(idb) {
+  return idb.createObjectStore(OBJECT_STORE);
+}

--- a/src/kv/idbstore.js
+++ b/src/kv/idbstore.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 const RELAXED = {durability: "relaxed"};
-
 const OBJECT_STORE = "chunks";
 
 /**
@@ -9,7 +8,7 @@ const OBJECT_STORE = "chunks";
  * @return {IDBTransaction}
  */
 export function readTransaction(idb) {
-  return idb.transaction(OBJECT_STORE, "readwrite");
+  return idb.transaction(OBJECT_STORE, "readonly");
 }
 
 /**


### PR DESCRIPTION
This uses `extern C` to expose js functions to Rust.

I ended up exposing more functions than `transaction` to reduce the
number of allocations and conversions needed between Rust and JS.