### PR TITLE
Use extern C for performance.now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ features = [
     "IdbTransaction",
     "IdbTransactionMode",
     "IdbVersionChangeEvent",
-    "Performance",
+    "Performance", # only needed for crates/bench
     "Request",
     "RequestInit",
     "RequestMode",

--- a/src/embed/dispatch.rs
+++ b/src/embed/dispatch.rs
@@ -83,7 +83,7 @@ pub async fn dispatch(db_name: String, rpc: String, data: JsValue) -> Response {
     lc.add_context("rpc", &rpc);
     lc.add_context("db", &db_name);
     debug!(lc, "-> data={:?}", &data);
-    let timer = rlog::Timer::new().map_err(to_debug)?;
+    let timer = rlog::Timer::new();
 
     let (tx, rx) = channel::<Response>(1);
     let request = Request {

--- a/src/sync/pull.rs
+++ b/src/sync/pull.rs
@@ -62,7 +62,7 @@ pub async fn begin_pull(
         schema_version,
     };
     debug!(lc, "Starting pull...");
-    let pull_timer = rlog::Timer::new().map_err(InternalTimerError)?;
+    let pull_timer = rlog::Timer::new();
     let (pull_resp, http_request_info) = puller
         .pull(&pull_req, &pull_url, &pull_auth, &request_id)
         .await

--- a/src/sync/push.rs
+++ b/src/sync/push.rs
@@ -185,7 +185,7 @@ pub async fn push(
             schema_version: req.schema_version,
         };
         debug!(lc, "Starting push...");
-        let push_timer = rlog::Timer::new().map_err(InternalTimerError)?;
+        let push_timer = rlog::Timer::new();
         let (_push_resp, req_info) = pusher
             .push(&push_req, &req.push_url, &req.push_auth, request_id)
             .await

--- a/src/sync/types.rs
+++ b/src/sync/types.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{dag, db, util::rlog};
+use crate::{dag, db};
 
 use super::{patch, PullError, PushError};
 
@@ -86,7 +86,6 @@ pub enum TryPushError {
     InternalGetPendingCommitsError(db::WalkChainError),
     InternalNoMainHeadError,
     InternalNonLocalPendingCommit,
-    InternalTimerError(rlog::TimerError),
     PushFailed(PushError),
     ReadError(dag::Error),
 }
@@ -100,7 +99,6 @@ pub enum BeginTryPullError {
     InternalNoMainHeadError,
     InternalProgrammerError(db::InternalProgrammerError),
     InternalRebuildIndexError(db::CreateIndexError),
-    InternalTimerError(rlog::TimerError),
     InvalidBaseSnapshotCookie(serde_json::error::Error),
     LockError(dag::Error),
     MainHeadDisappeared,

--- a/src/util/rlog/browser_timer.rs
+++ b/src/util/rlog/browser_timer.rs
@@ -1,30 +1,19 @@
 extern crate web_sys;
-use super::super::wasm::global_property;
-use super::errors::TimerError;
+use super::super::wasm::performance_now;
 
 pub struct Timer {
-    start_ms: u64,
-    performance: web_sys::Performance,
+    start_ms: f64,
 }
 
 impl Timer {
-    pub fn new() -> Result<Timer, TimerError> {
-        // We could use console::time_with_label here if we wanted.
-        let performance = get_performance()?;
-        let start_ms = performance.now() as u64;
-        Ok(Timer {
-            start_ms,
-            performance,
-        })
+    pub fn new() -> Timer {
+        // Consider using Date.now() since we do not use the fractions anyway
+        Timer {
+            start_ms: performance_now(),
+        }
     }
 
     pub fn elapsed_ms(self) -> u64 {
-        let end_ms = self.performance.now() as u64;
-        end_ms - self.start_ms
+        (performance_now() - self.start_ms) as u64
     }
-}
-
-fn get_performance() -> Result<web_sys::Performance, TimerError> {
-    use TimerError::*;
-    global_property("performance").map_err(|_| NoPerformanceTimer)
 }

--- a/src/util/rlog/browser_timer.rs
+++ b/src/util/rlog/browser_timer.rs
@@ -5,6 +5,12 @@ pub struct Timer {
     start_ms: f64,
 }
 
+impl Default for Timer {
+    fn default() -> Self {
+        Timer::new()
+    }
+}
+
 impl Timer {
     pub fn new() -> Timer {
         // Consider using Date.now() since we do not use the fractions anyway

--- a/src/util/rlog/errors.rs
+++ b/src/util/rlog/errors.rs
@@ -1,5 +1,0 @@
-#[derive(Debug)]
-pub enum TimerError {
-    NoPerformanceTimer,
-    NoWindow,
-}

--- a/src/util/rlog/mod.rs
+++ b/src/util/rlog/mod.rs
@@ -1,10 +1,8 @@
-mod errors;
 #[macro_use]
 pub mod logger;
 #[cfg_attr(target_arch = "wasm32", path = "browser_timer.rs")]
 #[cfg_attr(not(target_arch = "wasm32"), path = "rust_timer.rs")]
 mod timer;
 
-pub use errors::TimerError;
 pub use logger::LogContext;
 pub use timer::Timer;

--- a/src/util/rlog/rust_timer.rs
+++ b/src/util/rlog/rust_timer.rs
@@ -1,4 +1,3 @@
-use super::errors::TimerError;
 use std::time::Instant;
 
 pub struct Timer {
@@ -6,10 +5,10 @@ pub struct Timer {
 }
 
 impl Timer {
-    pub fn new() -> Result<Timer, TimerError> {
-        Ok(Timer {
+    pub fn new() -> Timer {
+        Timer {
             start: Instant::now(),
-        })
+        }
     }
 
     pub fn elapsed_ms(self) -> u64 {
@@ -23,7 +22,7 @@ mod tests {
 
     #[test]
     fn test_timer() {
-        let timer = Timer::new().unwrap();
+        let timer = Timer::new();
         let ten_ms = std::time::Duration::from_millis(10);
         std::thread::sleep(ten_ms);
         assert!(timer.elapsed_ms() > 0);

--- a/src/util/rlog/rust_timer.rs
+++ b/src/util/rlog/rust_timer.rs
@@ -4,6 +4,12 @@ pub struct Timer {
     start: Instant,
 }
 
+impl Default for Timer {
+    fn default() -> Self {
+        Timer::new()
+    }
+}
+
 impl Timer {
     pub fn new() -> Timer {
         Timer {

--- a/src/util/wasm/mod.js
+++ b/src/util/wasm/mod.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+/** @returns {number} */
+export function performanceNow() {
+  return performance.now();
+}

--- a/src/util/wasm/mod.rs
+++ b/src/util/wasm/mod.rs
@@ -1,3 +1,4 @@
+use wasm_bindgen::prelude::*;
 use wasm_bindgen::{JsCast, JsValue};
 
 pub fn global_property<T>(property: &str) -> Result<T, JsValue>
@@ -7,4 +8,10 @@ where
     let global = js_sys::global();
     let key = JsValue::from_str(property);
     js_sys::Reflect::get(&global, &key)?.dyn_into()
+}
+
+#[wasm_bindgen(module = "/src/util/wasm/mod.js")]
+extern "C" {
+    #[wasm_bindgen(js_name = performanceNow)]
+    pub fn performance_now() -> f64;
 }


### PR DESCRIPTION
Main motivation is to allow mocking of performance.now on the JS side

But generally, this way we do not need to represent performance to Rust.