### PR TITLE
Further optimize the wasm bundle with wasm-opt.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,11 @@ lto = true
 opt-level = 3
 panic = "abort"
 
+# It would be nice to use wasm-opt, but there are no prebuilt binaries for m1:
+# https://github.com/rustwasm/wasm-pack/issues/913
+# So we just run it separately in ./tool/release.sh.
+# Developers must manually build/install wasm-opt, which can be done on macs with Homebrew.
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-Oz"]
-
+wasm-opt = false
 [package.metadata.wasm-pack.profile.profiling]
-wasm-opt = ["-Oz", "-g"]
+wasm-opt = false

--- a/tool/release.sh
+++ b/tool/release.sh
@@ -34,8 +34,12 @@ fi
 
     rm repc.zip
     rm -rf pkg
-    wasm-pack build --profiling --target web --out-dir pkg/debug -- --no-default-features
+    wasm-pack build --debug --target web --out-dir pkg/debug -- --no-default-features
+    wasm-opt -O4 -o pkg/debug/replicache_client_bg.wasm pkg/debug/replicache_client_bg.wasm
+    brotli pkg/debug/replicache_client_bg.wasm
     wasm-pack build --release --target web --out-dir pkg/release -- --no-default-features
+    wasm-opt -O4 -o pkg/release/replicache_client_bg.wasm pkg/release/replicache_client_bg.wasm
+    brotli pkg/release/replicache_client_bg.wasm
     zip -r pkg pkg
     mv pkg.zip repc.zip
 


### PR DESCRIPTION
This shaves 10% off the compressed size and whatever it's doing, noticeably improves benchmarks too.