### PR TITLE
Run wasm-opt explicitly as part of tools/release.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,11 @@ lto = true
 opt-level = 3
 panic = "abort"
 
+# It would be nice to use wasm-opt, but there are no prebuilt binaries for m1:
+# https://github.com/rustwasm/wasm-pack/issues/913
+# So we just run it separately in ./tool/release.sh.
+# Developers must manually build/install wasm-opt, which can be done on macs with Homebrew.
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-Oz"]
-
+wasm-opt = false
 [package.metadata.wasm-pack.profile.profiling]
-wasm-opt = ["-Oz", "-g"]
+wasm-opt = false

--- a/tool/release.sh
+++ b/tool/release.sh
@@ -34,8 +34,12 @@ fi
 
     rm repc.zip
     rm -rf pkg
-    wasm-pack build --profiling --target web --out-dir pkg/debug -- --no-default-features
+    wasm-pack build --debug --target web --out-dir pkg/debug -- --no-default-features
+    wasm-opt -O4 -o pkg/debug/replicache_client_bg.wasm pkg/debug/replicache_client_bg.wasm
+    brotli pkg/debug/replicache_client_bg.wasm
     wasm-pack build --release --target web --out-dir pkg/release -- --no-default-features
+    wasm-opt -O4 -o pkg/release/replicache_client_bg.wasm pkg/release/replicache_client_bg.wasm
+    brotli pkg/release/replicache_client_bg.wasm
     zip -r pkg pkg
     mv pkg.zip repc.zip
 


### PR DESCRIPTION
There are no prebuilt binaries for M1, so wasm-pack just skips it.
However you can manually install wasm-opt and run it, so let's do
that.

Also:
- Put the brotli compression back. I think it's good for us to
  put our best foot forward in the binary, so to speak.
- Change "profiling" to "debug". There's no difference in file
  size between profiling and release. I have no idea what it's
  supposed to change. I figure if we're going to have a debug
  build let's at lease maximize its utility. With wasm-opt and
  brotli, the difference is only ~50% (the debug build is 300k),
  so it seems reasonable to expose to users. Maybe it will be a
  better debugging experience.