### PR TITLE
Use Vec<8> instead of string for ChangedKeys

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -22,6 +22,6 @@ pub use index::{
 pub use read::{read_commit, read_indexes, OwnedRead, Read, ReadCommitError, ScanError, Whence};
 pub use scan::{ScanItem, ScanOptions, ScanResult, ScanResultError};
 pub use write::{
-    init_db, ChangedKeysMap, ClearError, CommitError, CreateIndexError, DelError, DropIndexError,
-    InitDBError, PutError, Write,
+    changed_keys_map_to_rpc, init_db, ChangedKeysMap, ChangedKeysMapRpc, ClearError, CommitError,
+    CreateIndexError, DelError, DropIndexError, InitDBError, PutError, Write,
 };

--- a/src/embed/types.rs
+++ b/src/embed/types.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::redundant_pattern_matching)] // For derive(Deserialize).
 
-use crate::db::{self, ChangedKeysMap};
+use crate::db::{self, ChangedKeysMapRpc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -56,7 +56,7 @@ pub struct CommitTransactionResponse {
     #[serde(rename = "ref")]
     pub hash: String,
     #[serde(rename = "changedKeys")]
-    pub changed_keys: ChangedKeysMap,
+    pub changed_keys: ChangedKeysMapRpc,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/sync/types.rs
+++ b/src/sync/types.rs
@@ -1,7 +1,7 @@
 use super::{patch, ChangedKeysError, PullError, PushError};
 use crate::{
     dag,
-    db::{self, ChangedKeysMap},
+    db::{self, ChangedKeysMapRpc},
     prolly,
 };
 use serde::{Deserialize, Serialize};
@@ -33,7 +33,7 @@ pub struct MaybeEndTryPullResponse {
     #[serde(rename = "syncHead")]
     pub sync_head: String,
     #[serde(rename = "changedKeys")]
-    pub changed_keys: ChangedKeysMap,
+    pub changed_keys: ChangedKeysMapRpc,
 }
 
 // ReplayMutation is returned in the MaybeEndPushResponse, not be confused with


### PR DESCRIPTION
All the way to the RPC barrier, at which point we turn the Vec<u8> to a
String.