### PR TITLE
Throw an error instead of a string

### DIFF
--- a/src/embed/dispatch.rs
+++ b/src/embed/dispatch.rs
@@ -67,10 +67,10 @@ async fn dispatch_loop(rx: Receiver<Request>) {
             Some(tx) => tx.send(req).await,
             None => {
                 req.response
-                    .send(Err(JsValue::from_str(&format!(
+                    .send(Err(JsValue::from(js_sys::Error::new(&format!(
                         "\"{}\" not open",
                         req.db_name
-                    ))))
+                    )))))
                     .await;
             }
         };

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -19,7 +19,8 @@ pub async fn new_idbstore(name: String) -> Option<Box<dyn Store>> {
 #[wasm_bindgen]
 pub async fn dispatch(db_name: String, rpc: u8, args: JsValue) -> Result<JsValue, JsValue> {
     init_panic_hook();
-    let rpc = Rpc::from_u8(rpc).ok_or_else(|| JsValue::from(format!("Invalid RPC: {:?}", rpc)))?;
+    let rpc = Rpc::from_u8(rpc)
+        .ok_or_else(|| JsValue::from(js_sys::Error::new(&format!("Invalid RPC: {:?}", rpc))))?;
     embed::dispatch(db_name, rpc, args).await
 }
 


### PR DESCRIPTION
At the top level exit point from wasm throw an Error instead of a
string.

Towards #352