### PR TITLE
Make Mutation args use JSON Value

### DIFF
--- a/src/sync/pull.rs
+++ b/src/sync/pull.rs
@@ -268,6 +268,7 @@ pub async fn maybe_end_try_pull(
                     ))
                 }
             };
+            let args: serde_json::Value = serde_json::from_str(&args).map_err(InvalidJson)?;
             replay_mutations.push(ReplayMutation {
                 id: c.mutation_id(),
                 name,
@@ -1429,6 +1430,8 @@ mod tests {
                                 let got_args = &resp.replay_mutations[i].args;
                                 let exp_args =
                                     String::from_utf8(lm.mutator_args_json().to_vec()).unwrap();
+                                let exp_args: serde_json::Value =
+                                    serde_json::from_str(&exp_args).unwrap();
                                 assert_eq!(&exp_args, got_args);
                             }
                             _ => panic!("inconceivable"),

--- a/src/sync/types.rs
+++ b/src/sync/types.rs
@@ -47,7 +47,7 @@ pub struct MaybeEndTryPullResponse {
 pub struct ReplayMutation {
     pub id: u64,
     pub name: String,
-    pub args: String,
+    pub args: serde_json::Value,
     pub original: String,
 }
 
@@ -129,6 +129,7 @@ pub enum MaybeEndTryPullError {
     InternalArgsUtf8Error(std::string::FromUtf8Error),
     InternalProgrammerError(String),
     InvalidUtf8(std::string::FromUtf8Error),
+    InvalidJson(serde_json::Error),
     LoadHeadError(prolly::LoadError),
     LoadSyncHeadError(db::FromHashError),
     MissingMainHead,


### PR DESCRIPTION
This type is currently only used in the RPC between JS and Rust but a
future change will expose this type to the JS API and therefore it makes
sense to use a JSON Value at this layer instead.